### PR TITLE
Client API Base

### DIFF
--- a/src/client/coll.rs
+++ b/src/client/coll.rs
@@ -1,0 +1,201 @@
+use bson;
+use client::db::Database;
+use client::common::{ReadPreference, WriteConcern};
+use client::wire_protocol::operations::{OpQueryFlags, Message};
+
+/// Interfaces with a MongoDB collection.
+pub struct Collection<'a> {
+    db: &'a Database<'a>,
+    pub name: String,
+    pub full_name: String,
+    read_preference: Option<ReadPreference>,
+    write_concern: Option<WriteConcern>,
+}
+
+#[derive(Clone, PartialEq)]
+pub enum CursorType {
+    NonTailable,
+    Tailable,
+    TailableAwait,
+}
+
+#[derive(Clone)]
+pub struct AggregateOptions {
+    pub allow_disk_use: bool,
+    pub use_cursor: bool,
+    pub batch_size: Option<i32>,
+    pub max_time_ms: Option<i64>,
+}
+
+#[derive(Clone)]
+pub struct CountOptions {
+    pub hint: Option<bson::Document>,
+    pub limit: Option<i64>,
+    pub max_time_ms: Option<i64>,
+    pub skip: Option<i64>,
+}
+
+#[derive(Clone)]
+pub struct DistinctOptions {
+    pub max_time_ms: Option<i64>,
+}
+
+#[derive(Clone)]
+pub struct FindOptions {
+    pub allow_partial_results: bool,
+    pub no_cursor_timeout: bool,
+    pub op_log_replay: bool,
+    pub skip: i32,
+    pub limit: i32,
+    pub cursor_type: CursorType,
+    pub batch_size: Option<i32>,
+    pub comment: Option<String>,
+    pub max_time_ms: Option<i64>,
+    pub modifiers: Option<bson::Document>,
+    pub projection: Option<bson::Document>,
+    pub sort: Option<bson::Document>,
+}
+
+impl FindOptions {
+    /// Creates a new FindOptions struct with default parameters.
+    pub fn new() -> FindOptions {
+        FindOptions {
+            allow_partial_results: false,
+            no_cursor_timeout: false,
+            op_log_replay: false,
+            skip: 0,
+            limit: 0,
+            cursor_type: CursorType::NonTailable,
+            batch_size: None,
+            comment: None,
+            max_time_ms: None,
+            modifiers: None,
+            projection: None,
+            sort: None,
+        }
+    }
+
+    pub fn with_skip(&self, skip: i32) -> FindOptions {
+        let mut new_opts = self.clone();
+        new_opts.skip = skip;
+        new_opts
+    }
+
+    pub fn with_limit(&self, limit: i32) -> FindOptions {
+        let mut new_opts = self.clone();
+        new_opts.limit = limit;
+        new_opts
+    }
+
+    pub fn with_projection(&self, proj: Option<bson::Document>) -> FindOptions {
+        let mut new_opts = self.clone();
+        new_opts.projection = proj;
+        new_opts
+    }
+}
+
+impl<'a> Collection<'a> {
+    /// Creates a collection representation with optional read and write controls.
+    ///
+    /// If `create` is specified, the collection will be explicitly created in the database.
+    pub fn new(db: &'a Database<'a>, name: &str, create: bool,
+               read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Collection<'a> {
+
+        let coll = Collection {
+            full_name: format!("{}.{}", db.name, name),
+            db: db,
+            name: name.to_owned(),
+            read_preference: read_preference,
+            write_concern: write_concern,
+        };
+
+        /*
+        // Since standard collections are implicitly created on insert,
+        // this should only be used to create capped collections.
+        if create {
+            coll.create();
+        };
+         */
+
+        coll
+    }
+
+    /// Returns a unique operational request id.
+    pub fn get_req_id(&self) -> i32 {
+        self.db.client.get_req_id()
+    }
+
+    // Read Spec
+    pub fn aggregate(pipeline: &[bson::Document], options: AggregateOptions) -> Result<Vec<bson::Document>, String> {
+        Err("IMPL".to_owned())
+    }
+
+    pub fn count(filter: bson::Document, options: CountOptions) -> Result<i64, String> {
+        Err("IMPL".to_owned())
+    }
+
+    pub fn distinct(field_name: &str, filter: bson::Document, options: DistinctOptions) -> Result<Vec<String>, String> {
+        Err("IMPL".to_owned())
+    }
+
+    /// Returns a list of documents within the collection that match the filter.
+    pub fn find(&self, filter: Option<bson::Document>, options: Option<FindOptions>)
+                -> Result<Vec<bson::Document>, String> {
+
+        let doc = match filter {
+            Some(bson) => bson,
+            None => bson::Document::new(),
+        };
+
+        let options = match options {
+            Some(opts) => opts,
+            None => FindOptions::new(),
+        };
+
+        let flags = OpQueryFlags {
+            tailable_cursor: options.cursor_type != CursorType::NonTailable,
+            slave_ok: false,
+            oplog_relay: options.op_log_replay,
+            no_cursor_timeout: options.no_cursor_timeout,
+            await_data: options.cursor_type == CursorType::TailableAwait,
+            exhaust: false,
+            partial: options.allow_partial_results,
+        };
+
+        let req = try!(Message::with_query(self.get_req_id(), flags, self.full_name.to_owned(),
+                                           options.skip, options.limit, doc, options.projection));
+
+        try!(req.write(&mut *self.db.client.socket.borrow_mut()));
+        let bson = try!(Message::read(&mut *self.db.client.socket.borrow_mut()));
+        Ok(vec!(bson))
+    }
+
+    /// Returns the first document within the collection that matches the filter, or None.
+    pub fn find_one(&self, filter: Option<bson::Document>, options: Option<FindOptions>)
+                    -> Result<Option<bson::Document>, String> {
+
+        let options = match options {
+            Some(opts) => opts,
+            None => FindOptions::new(),
+        };
+
+        let res = try!(self.find(filter, Some(options.with_limit(1))));
+        match res.len() {
+            0 => Ok(None),
+            _ => Ok(Some(res[0].to_owned())),
+        }
+    }
+
+    // Write Spec
+    fn insert(&self, docs: &[bson::Document]) -> Result<bson::Document, String> {
+        Err("IMPL".to_owned())
+    }
+
+    pub fn insert_one(&self, doc: bson::Document) -> Result<bson::Document, String> {
+        Err("IMPL".to_owned())
+    }
+
+    pub fn insert_many(&self, docs: &[bson::Document], ordered: bool) -> Result<bson::Document, String> {
+        Err("IMPL".to_owned())
+    }
+}

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, PartialEq)]
 pub enum ReadPreference {
     Primary,
     PrimaryPreferred,
@@ -6,6 +7,7 @@ pub enum ReadPreference {
     Nearest,
 }
 
+#[derive(Clone)]
 pub struct WriteConcern {
     w: i8,           // Write replication
     w_timeout: i32,  // Used in conjunction with 'w'. Propagation timeout in ms.

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ReadPreference {
     Primary,
     PrimaryPreferred,
@@ -9,19 +9,19 @@ pub enum ReadPreference {
 
 #[derive(Clone)]
 pub struct WriteConcern {
-    w: i8,           // Write replication
-    w_timeout: i32,  // Used in conjunction with 'w'. Propagation timeout in ms.
-    j: bool,         // If true, will block until write operations have been committed to journal.
-    fsync: bool,     // If true and server is not journaling, blocks until server has synced all data files to disk.
+    pub w: i8,           // Write replication
+    pub w_timeout: i32,  // Used in conjunction with 'w'. Propagation timeout in ms.
+    pub j: bool,         // If true, will block until write operations have been committed to journal.
+    pub fsync: bool,     // If true and server is not journaling, blocks until server has synced all data files to disk.
 }
 
 impl WriteConcern {
-    pub fn new(w: i8, w_timeout: i32, j: bool, fsync: bool) -> WriteConcern {
+    pub fn new() -> WriteConcern {
         WriteConcern {
-            w: w,
-            w_timeout: w_timeout,
-            j: j,
-            fsync: fsync,
+            w: 1,
+            w_timeout: 0,
+            j: false,
+            fsync: false,
         }
     }
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,0 +1,25 @@
+pub enum ReadPreference {
+    Primary,
+    PrimaryPreferred,
+    Secondary,
+    SecondaryPreferred,
+    Nearest,
+}
+
+pub struct WriteConcern {
+    w: i8,           // Write replication
+    w_timeout: i32,  // Used in conjunction with 'w'. Propagation timeout in ms.
+    j: bool,         // If true, will block until write operations have been committed to journal.
+    fsync: bool,     // If true and server is not journaling, blocks until server has synced all data files to disk.
+}
+
+impl WriteConcern {
+    pub fn new(w: i8, w_timeout: i32, j: bool, fsync: bool) -> WriteConcern {
+        WriteConcern {
+            w: w,
+            w_timeout: w_timeout,
+            j: j,
+            fsync: fsync,
+        }
+    }
+}

--- a/src/client/connstring.rs
+++ b/src/client/connstring.rs
@@ -86,7 +86,7 @@ impl ConnectionString {
     }
 }
 
-/// Parses a MongoDB connection string URI as defined by
+/// Parses a MongoDB connection string URI as defined by 
 /// [the manual](http://docs.mongodb.org/manual/reference/connection-string/).
 pub fn parse(address: &str) -> Result<ConnectionString, &str> {
     if !address.starts_with(URI_SCHEME) {

--- a/src/client/db.rs
+++ b/src/client/db.rs
@@ -1,0 +1,98 @@
+use bson;
+use bson::Bson;
+use client::MongoClient;
+use client::coll::Collection;
+use client::common::{ReadPreference, WriteConcern};
+
+/// Interfaces with a MongoDB database.
+pub struct Database<'a> {
+    pub name: String,
+    pub client: &'a MongoClient,
+    read_preference: Option<ReadPreference>,
+    write_concern: Option<WriteConcern>,
+}
+
+impl<'a> Database<'a> {
+    /// Creates a database representation with optional read and write controls.
+    pub fn new(client: &'a MongoClient, name: &str,
+               read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Database<'a> {
+        Database {
+            name: name.to_owned(),
+            client: client,
+            read_preference: read_preference,
+            write_concern: write_concern,
+        }
+    }
+
+    /// Return a unique operational request id.
+    pub fn get_req_id(&self) -> i32 {
+        self.client.get_req_id()
+    }
+
+    // Sends an administrative command over find_one.
+    fn command(&'a self, spec: bson::Document) -> Result<Option<bson::Document>, String> {
+        let coll = Collection::new(self, "$cmd", false, None, None);
+        coll.find_one(Some(spec), None)
+    }
+
+    /// Returns a list of collections within the database.
+    pub fn list_collections(&'a self) -> Result<Vec<Collection<'a>>, String> {
+        let mut spec = bson::Document::new();
+        spec.insert("listCollections".to_owned(), Bson::I32(1));
+        let res = try!(self.command(spec));
+
+        if res.is_none() {
+            return Ok(vec!());
+        }
+
+        let bson = res.unwrap();
+
+        // Wire/Client proof of concept; replace this with cursor implementation in the future.
+        // Unwrap reply
+        if let Some(&Bson::Document(ref cursor)) = bson.get("cursor") {
+            // Unwrap batched results
+            if let Some(&Bson::Array(ref batch)) = cursor.get("firstBatch") {
+                // Iterate over each collection returned
+                let mut collections = Vec::new();
+                for bdoc in batch {
+                    // Unwrap document
+                    if let &Bson::Document(ref doc) = bdoc {
+                        // Unwrap name
+                        if let Some(&Bson::String(ref name)) = doc.get("name") {
+                            // Push collection into returned results
+                            collections.push(Collection::new(self, &name[..], false, None, None));
+                        }
+                    }
+                };
+                return Ok(collections);
+            }
+        }
+
+        Err("Unable to unwrap collections list.".to_owned())
+    }
+
+    /// Returns a list of collection names within the database.
+    pub fn collection_names(&'a self) -> Result<Vec<String>, String> {
+        let results = try!(self.list_collections());
+        Ok(results.iter().map(|coll| coll.name.to_owned()).collect())
+    }
+
+    /// Creates a new collection.
+    ///
+    /// Note that due to the implicit creation of collections during insertion, this
+    /// method should only be used to instantiate capped collections.
+    pub fn create_collection(&'a self, db: &str, name: &str) -> Result<(), String> {
+        //let mut spec = bson::Document::new();
+        //spec.insert("createCollection".to_owned(), Bson::I32(1));
+        //let res = try!(self.command(&spec));
+        Err("IMPL".to_owned())
+    }
+
+    /// Permanently deletes the database from the server.
+    pub fn drop_database(&'a self) -> Result<(), String> {
+        let mut spec = bson::Document::new();
+        spec.insert("dropDatabase".to_owned(), Bson::I32(1));
+        try!(self.command(spec));
+        Ok(())
+    }
+}

--- a/src/client/db.rs
+++ b/src/client/db.rs
@@ -8,25 +8,36 @@ use client::common::{ReadPreference, WriteConcern};
 pub struct Database<'a> {
     pub name: String,
     pub client: &'a MongoClient,
-    read_preference: Option<ReadPreference>,
-    write_concern: Option<WriteConcern>,
+    pub read_preference: ReadPreference,
+    pub write_concern: WriteConcern,
 }
 
 impl<'a> Database<'a> {
     /// Creates a database representation with optional read and write controls.
     pub fn new(client: &'a MongoClient, name: &str,
                read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Database<'a> {
+
+        let rp = match read_preference {
+            Some(rp) => rp,
+            None => client.read_preference.to_owned(),
+        };
+
+        let wc = match write_concern {
+            Some(wc) => wc,
+            None => client.write_concern.to_owned(),
+        };
+
         Database {
             name: name.to_owned(),
             client: client,
-            read_preference: read_preference,
-            write_concern: write_concern,
+            read_preference: rp,
+            write_concern: wc,
         }
     }
 
     /// Creates a collection representation with inherited read and write controls.
     pub fn collection(&'a self, coll_name: &str) -> Collection<'a> {
-        Collection::new(self, coll_name, false, self.read_preference.to_owned(), self.write_concern.to_owned())
+        Collection::new(self, coll_name, false, Some(self.read_preference.to_owned()), Some(self.write_concern.to_owned()))
     }
 
     /// Creates a collection representation with custom read and write controls.
@@ -34,7 +45,7 @@ impl<'a> Database<'a> {
                                  read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Collection<'a> {
         Collection::new(self, coll_name, create, read_preference, write_concern)
     }
-    
+
     /// Return a unique operational request id.
     pub fn get_req_id(&self) -> i32 {
         self.client.get_req_id()
@@ -85,18 +96,15 @@ impl<'a> Database<'a> {
     /// Returns a list of collection names within the database.
     pub fn collection_names(&'a self) -> Result<Vec<String>, String> {
         let results = try!(self.list_collections());
-        Ok(results.iter().map(|coll| coll.name.to_owned()).collect())
+        Ok(results.iter().map(|coll| coll.name()).collect())
     }
 
     /// Creates a new collection.
     ///
     /// Note that due to the implicit creation of collections during insertion, this
     /// method should only be used to instantiate capped collections.
-    pub fn create_collection(&'a self, db: &str, name: &str) -> Result<(), String> {
-        //let mut spec = bson::Document::new();
-        //spec.insert("createCollection".to_owned(), Bson::I32(1));
-        //let res = try!(self.command(&spec));
-        Err("IMPL".to_owned())
+    pub fn create_collection(&'a self, name: &str) -> Result<(), String> {
+        unimplemented!()
     }
 
     /// Permanently deletes the database from the server.

--- a/src/client/db.rs
+++ b/src/client/db.rs
@@ -24,6 +24,17 @@ impl<'a> Database<'a> {
         }
     }
 
+    /// Creates a collection representation with inherited read and write controls.
+    pub fn collection(&'a self, coll_name: &str) -> Collection<'a> {
+        Collection::new(self, coll_name, false, self.read_preference.to_owned(), self.write_concern.to_owned())
+    }
+
+    /// Creates a collection representation with custom read and write controls.
+    pub fn collection_with_prefs(&'a self, coll_name: &str, create: bool,
+                                 read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Collection<'a> {
+        Collection::new(self, coll_name, create, read_preference, write_concern)
+    }
+    
     /// Return a unique operational request id.
     pub fn get_req_id(&self) -> i32 {
         self.client.get_req_id()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,2 +1,68 @@
+pub mod db;
+pub mod coll;
+pub mod common;
 pub mod connstring;
 pub mod wire_protocol;
+
+use std::cell::{Cell, RefCell};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use client::db::Database;
+use client::connstring::ConnectionString;
+
+/// Interfaces with a MongoDB server or replica set.
+pub struct MongoClient {
+    req_id: Cell<i32>,
+    socket: Arc<RefCell<TcpStream>>,
+    config: ConnectionString,
+}
+
+impl MongoClient {
+    /// Creates a new MongoClient connected to a single MongoDB server.
+    pub fn new(host: &str, port: u16) -> Result<MongoClient, String> {
+        let config = ConnectionString::new(host, port);
+        MongoClient::with_config(config)
+    }
+
+    /// Creates a new MongoClient connected to a server or replica set using 
+    /// a MongoDB connection string URI as defined by 
+    /// [the manual](http://docs.mongodb.org/manual/reference/connection-string/).
+    pub fn with_uri(uri: &str) -> Result<MongoClient, String> {
+        let config = try!(connstring::parse(uri));
+        MongoClient::with_config(config)
+    }
+
+    fn with_config(config: ConnectionString) -> Result<MongoClient, String> {
+        let socket = try!(MongoClient::connect(&config));
+        Ok(MongoClient {
+            req_id: Cell::new(0),
+            socket: Arc::new(RefCell::new(socket)),
+            config: config,
+        })
+    }
+
+    /// Returns a unique operational request id.
+    pub fn get_req_id(&self) -> i32 {
+        self.req_id.set(self.req_id.get() + 1);
+        self.req_id.get()
+    }
+
+    // Connects to a MongoDB server as defined by `config`.
+    fn connect(config: &ConnectionString) -> Result<TcpStream, String> {
+        let host_name = config.hosts[0].host_name.to_owned();
+        let port = config.hosts[0].port;
+
+        match TcpStream::connect((&host_name[..], port)) {
+            Ok(sock) => Ok(sock),
+            Err(_) => return Err(format!("Failed to connect to host '{}:{}'", host_name, port)),
+        }
+    }
+
+    /// Drops the database defined by `db_name`.
+    pub fn drop_database(&self, db_name: &str) -> Result<(), String> {
+        let db = Database::new(self, db_name, None, None);
+        try!(db.drop_database());
+        Ok(())
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,29 +18,58 @@ pub struct MongoClient {
     req_id: Arc<AtomicIsize>,
     socket: Arc<Mutex<RefCell<TcpStream>>>,
     config: ConnectionString,
+    pub read_preference: ReadPreference,
+    pub write_concern: WriteConcern,
 }
 
 impl MongoClient {
     /// Creates a new MongoClient connected to a single MongoDB server.
     pub fn new(host: &str, port: u16) -> Result<MongoClient, String> {
-        let config = ConnectionString::new(host, port);
-        MongoClient::with_config(config)
+        MongoClient::with_prefs(host, port, None, None)
     }
 
-    /// Creates a new MongoClient connected to a server or replica set using 
-    /// a MongoDB connection string URI as defined by 
+    /// `new` with custom read and write controls.
+    pub fn with_prefs(host: &str, port: u16, read_pref: Option<ReadPreference>,
+                      write_concern: Option<WriteConcern>) -> Result<MongoClient, String> {
+        let config = ConnectionString::new(host, port);
+        MongoClient::with_config(config, read_pref, write_concern)
+    }
+
+    /// Creates a new MongoClient connected to a server or replica set using
+    /// a MongoDB connection string URI as defined by
     /// [the manual](http://docs.mongodb.org/manual/reference/connection-string/).
     pub fn with_uri(uri: &str) -> Result<MongoClient, String> {
-        let config = try!(connstring::parse(uri));
-        MongoClient::with_config(config)
+        MongoClient::with_uri_and_prefs(uri, None, None)
     }
 
-    fn with_config(config: ConnectionString) -> Result<MongoClient, String> {
+    /// `with_uri` with custom read and write controls.
+    pub fn with_uri_and_prefs(uri: &str, read_pref: Option<ReadPreference>,
+                              write_concern: Option<WriteConcern>) -> Result<MongoClient, String> {
+        let config = try!(connstring::parse(uri));
+        MongoClient::with_config(config, read_pref, write_concern)
+    }
+
+    fn with_config(config: ConnectionString, read_pref: Option<ReadPreference>,
+                   write_concern: Option<WriteConcern>) -> Result<MongoClient, String> {
+
         let socket = try!(MongoClient::connect(&config));
+
+        let rp = match read_pref {
+            Some(rp) => rp,
+            None => ReadPreference::Primary,
+        };
+
+        let wc = match write_concern {
+            Some(wc) => wc,
+            None => WriteConcern::new(),
+        };
+
         Ok(MongoClient {
             req_id: Arc::new(ATOMIC_ISIZE_INIT),
             socket: Arc::new(Mutex::new(RefCell::new(socket))),
             config: config,
+            read_preference: rp,
+            write_concern: wc,
         })
     }
 
@@ -51,7 +80,7 @@ impl MongoClient {
 
     /// Creates a database representation with custom read and write controls.
     pub fn db_with_prefs<'a>(&'a self, db_name: &str, read_preference: Option<ReadPreference>,
-                         write_concern: Option<WriteConcern>) -> Database<'a> {
+                             write_concern: Option<WriteConcern>) -> Database<'a> {
         Database::new(self, db_name, read_preference, write_concern)
     }
 

--- a/src/client/wire_protocol/operations.rs
+++ b/src/client/wire_protocol/operations.rs
@@ -28,13 +28,13 @@ impl ByteLength for BsonDocument {
 }
 
 pub struct OpQueryFlags {
-    tailable_cursor: bool,    // Bit 1
-    slave_ok: bool,           // Bit 2
-    oplog_relay: bool,        // Bit 3
-    no_cursor_timeout: bool,  // Bit 4
-    await_data: bool,         // Bit 5
-    exhaust: bool,            // Bit 6
-    partial: bool,            // Bit 7
+    pub tailable_cursor: bool,    // Bit 1
+    pub slave_ok: bool,           // Bit 2
+    pub oplog_relay: bool,        // Bit 3
+    pub no_cursor_timeout: bool,  // Bit 4
+    pub await_data: bool,         // Bit 5
+    pub exhaust: bool,            // Bit 6
+    pub partial: bool,            // Bit 7
 
     // All other bits are 0
 }

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -10,8 +10,8 @@ use std::net::TcpStream;
 //#[test]
 fn find() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
-    let db = Database::new(&client, "sample", None, None);
-    let coll = Collection::new(&db, "movies", false, None, None);
+    let db = client.db("sample");
+    let coll = db.collection("movies");
     
     let results = coll.find(None, None).unwrap();
 
@@ -27,8 +27,8 @@ fn find() {
 //#[test]
 fn find_one() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
-    let db = Database::new(&client, "sample", None, None);
-    let coll = Collection::new(&db, "movies", false, None, None);
+    let db = client.db("sample");
+    let coll = db.collection("movies");
     
     let result = coll.find_one(None, None).unwrap();
 
@@ -44,7 +44,7 @@ fn find_one() {
 //#[test]
 fn list_collections() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
-    let db = Database::new(&client, "sample", None, None);
+    let db = client.db("sample");
     let result = db.list_collections().unwrap();
     assert!(result.len() > 0);
 }

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -1,0 +1,50 @@
+use bson::Document;
+use bson::Bson;
+use mongodb::client::wire_protocol::operations::{OpQueryFlags, Message};
+use mongodb::client::MongoClient;
+use mongodb::client::db::Database;
+use mongodb::client::coll::{Collection, FindOptions};
+use std::io::Write;
+use std::net::TcpStream;
+
+//#[test]
+fn find() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = Database::new(&client, "sample", None, None);
+    let coll = Collection::new(&db, "movies", false, None, None);
+    
+    let results = coll.find(None, None).unwrap();
+
+    assert!(results.len() > 0);
+    let expected_val = &Bson::String("Jaws".to_owned());
+    
+    match results[0].get("title") {
+        Some(expected_val) => (),
+        _ => panic!("Wrong value returned!"),
+    };
+}
+
+//#[test]
+fn find_one() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = Database::new(&client, "sample", None, None);
+    let coll = Collection::new(&db, "movies", false, None, None);
+    
+    let result = coll.find_one(None, None).unwrap();
+
+    assert!(result.is_some());
+    let expected_val = &Bson::String("Jaws".to_owned());
+    
+    match result.unwrap().get("title") {
+        Some(expected_val) => (),
+        _ => panic!("Wrong value returned!"),
+    };
+}
+
+//#[test]
+fn list_collections() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = Database::new(&client, "sample", None, None);
+    let result = db.list_collections().unwrap();
+    assert!(result.len() > 0);
+}

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -1,2 +1,3 @@
+mod coll;
 mod connstring;
 mod wire_protocol;


### PR DESCRIPTION
Basic client with ```find``` and ```find_one``` on collections, and basic commands on databases. Skeleton included for other Query/Insert options and operations.

See tests for example client usage.