### PR TITLE
run some real tests against mongodb 2.6 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
     - sudo make install
     - sudo ldconfig /usr/local/lib
 
-before_script: "echo \"db.test.insert({ foo: 42 }); db.getSiblingDB('sample').movies.insert({ title: 'Jaws' });\" | mongo"
+before_script: "db.getSiblingDB('sample').movies.insert({ title: 'Jaws' });\" | mongo"
 
 script:
     - cargo build --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
 
+services:
+    - "mongodb"
+
 before_install:
     - sudo apt-get install git-core automake autoconf libtool gcc
     - git clone git://github.com/mongodb/libbson.git
@@ -8,6 +11,8 @@ before_install:
     - make
     - sudo make install
     - sudo ldconfig /usr/local/lib
+
+before_script: "echo \"db.test.insert({ foo: 42 }); db.getSiblingDB('sample').movies.insert({ title: 'Jaws' });\" | mongo"
 
 script:
     - cargo build --verbose

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -7,7 +7,7 @@ use mongodb::client::coll::{Collection, FindOptions};
 use std::io::Write;
 use std::net::TcpStream;
 
-//#[test]
+#[test]
 fn find() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
     let db = client.db("sample");
@@ -24,7 +24,7 @@ fn find() {
     };
 }
 
-//#[test]
+#[test]
 fn find_one() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
     let db = client.db("sample");

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -7,6 +7,7 @@ use std::net::TcpStream;
 // Not prefixing this with "#[test]" since it requires both a server to be
 // running locally and the correct database state to pass, and we don't want
 // Travis to fail.
+#[test]
 fn wire_protocol() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {


### PR DESCRIPTION
@kyeah @saghmrossi this will enable us to run tests in Travis until we get insert working.

The only test that's excluded for now is the `list_collections()` one, because list_collections got a big overhaul in 3.0 and our current implementation is incompatible with mongodb 2.6, which is fine. We'll figure out a way to use [mongodb-version-manager](https://www.npmjs.com/package/mongodb-version-manager) or something similar to make travis use mongodb 3.0 sometime next week.