### PR TITLE
Integrate cursors into find queries

### DIFF
--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -50,7 +50,7 @@ pub enum WriteModel {
 pub struct AggregateOptions {
     pub allow_disk_use: bool,
     pub use_cursor: bool,
-    pub batch_size: Option<i32>,
+    pub batch_size: i32,
     pub max_time_ms: Option<i64>,
     pub read_preference: Option<ReadPreference>,
 }
@@ -81,7 +81,7 @@ pub struct FindOptions {
     pub skip: u32,
     pub limit: i32,
     pub cursor_type: CursorType,
-    pub batch_size: Option<i32>,
+    pub batch_size: i32,
     pub comment: Option<String>,
     pub max_time_ms: Option<i64>,
     pub modifiers: Option<bson::Document>,
@@ -128,7 +128,7 @@ impl FindOptions {
             skip: 0,
             limit: 0,
             cursor_type: CursorType::NonTailable,
-            batch_size: None,
+            batch_size: 20,
             comment: None,
             max_time_ms: None,
             modifiers: None,

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -1,4 +1,5 @@
 use bson;
+use client::cursor;
 use client::common::ReadPreference;
 
 /// Describes the type of cursor to return on collection queries.
@@ -128,7 +129,7 @@ impl FindOptions {
             skip: 0,
             limit: 0,
             cursor_type: CursorType::NonTailable,
-            batch_size: 20,
+            batch_size: cursor::DEFAULT_BATCH_SIZE,
             comment: None,
             max_time_ms: None,
             modifiers: None,

--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -217,7 +217,7 @@ impl <'a> Cursor<'a> {
         if self.limit > 0 && self.count >= self.limit {
             false
         } else {
-            if self.buffer.is_empty() {
+            if self.buffer.is_empty() && self.limit != 1 {
                 self.get_from_stream();
             }
             !self.buffer.is_empty()
@@ -235,21 +235,11 @@ impl <'a> Iterator for Cursor<'a> {
     /// Returns the document that was read, or `None` if there are no more
     /// documents to read.
     fn next(&mut self) -> Option<bson::Document> {
-        if self.limit != 0 && self.count >= self.limit {
-            return None;
-        }
-
-        self.count += 1;
-
-        match self.buffer.pop_front() {
-            Some(bson) => Some(bson),
-            None => {
-                if self.limit != 1 {
-                    self.next_from_stream()
-                } else {
-                    None
-                }
-            }
+        if self.has_next() {
+            self.count += 1;
+            self.buffer.pop_front()
+        } else {
+            None
         }
     }
 }

--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -1,6 +1,10 @@
 use bson;
+
+use client::coll::Collection;
+
 use client::wire_protocol::flags::OpQueryFlags;
 use client::wire_protocol::operations::Message;
+
 use std::collections::vec_deque::VecDeque;
 use std::io::{Read, Write};
 
@@ -14,18 +18,16 @@ use std::io::{Read, Write};
 ///                          beginning with the database name and a period.
 /// `batch_size` - How many documents to fetch at a given time from the server.
 /// `cursor_id` - Uniquely identifies the cursor being returned by the reply.
-pub struct Cursor<'a, T> where T: Read + Write + 'a {
-    request_id: i32,
-    namespace: String,
+pub struct Cursor<'a> {
+    collection: &'a Collection<'a>,
     batch_size: i32,
     cursor_id: i64,
     limit: i32,
     count: i32,
     buffer: VecDeque<bson::Document>,
-    stream: &'a mut T,
 }
 
-impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
+impl <'a> Cursor<'a> {
     /// Gets the cursor id and BSON documents from a reply Message.
     ///
     /// # Arguments
@@ -43,7 +45,7 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
                 let mut v = VecDeque::new();
 
                 for doc in docs {
-                    v.push_back(doc);
+                    v.push_back(doc.clone());
                 }
 
                 Some((v, cid))
@@ -57,12 +59,9 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     ///
     /// # Arguments
     ///
-    /// `stream` - The stream to read the input from and write the output to.
+    /// `collection` - The collection to read from.
     /// `batch_size` - How many documents the cursor should return at a time.
-    /// `request_id` - The request ID to be placed in the message header.
     /// `flags` - Bit vector of query options.
-    /// `namespace` - The full qualified name of the collection, beginning with
-    ///               the database name and a dot.
     /// `number_to_skip` - The number of initial documents to skip over in the
     ///                    query results.
     /// `number_to_return - The total number of documents that should be
@@ -75,41 +74,35 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     ///
     /// Returns the cursor for the query results on success, or an error string
     /// on failure.
-    pub fn query_with_batch_size(stream: &'a mut T, batch_size: i32,
-                                 request_id: i32, flags: OpQueryFlags,
-                                 namespace: &str, number_to_skip: i32,
-                                 number_to_return: i32, query: bson::Document,
-                                 return_field_selector: Option<bson::Document>) -> Result<Cursor<'a, T>, String> {
-        let result = Message::with_query(request_id, flags,
-                                         namespace.to_owned(),
-                                         number_to_skip, batch_size,
+    pub fn query_with_batch_size(collection: &'a Collection<'a>,
+                                 batch_size: i32,
+                                 flags: OpQueryFlags,
+                                 number_to_skip: i32, number_to_return: i32,
+                                 query: bson::Document,
+                                 return_field_selector: Option<bson::Document>) -> Result<Cursor<'a>, String> {
+        let result = Message::with_query(collection.get_req_id(), flags,
+                                         collection.namespace.to_owned(),
+                                         number_to_skip, number_to_return,
                                          query, return_field_selector);
 
-        let message = match result {
-            Ok(m) => m,
-            Err(s) => return Err(s)
+        let socket = match collection.db.client.socket.lock() {
+            Ok(val) => val,
+            Err(_) => return Err("Socket lock is poisoned.".to_owned()),
         };
 
-        match message.write(stream) {
-            Ok(_) => (),
-            Err(s) => return Err(s)
-        };
+        let message = try!(result);
+        try!(message.write(&mut *socket.borrow_mut()));
+        let reply = try!(Message::read(&mut *socket.borrow_mut()));
 
-        let reply  = match Message::read(stream) {
-            Ok(m) => m,
-            Err(s) => return Err(s)
-        };
-
-        match Cursor::<T>::get_bson_and_cid_from_message(reply) {
+        match Cursor::get_bson_and_cid_from_message(reply) {
             Some((buf, cursor_id)) => Ok(Cursor {
-                request_id: request_id,
-                namespace: namespace.to_owned(),
+                collection: collection,
                 batch_size: batch_size,
                 cursor_id: cursor_id,
                 limit: number_to_return,
                 count: 0,
                 buffer: buf,
-                stream: stream }),
+            }),
             None => Err("Invalid response received".to_owned()),
         }
     }
@@ -118,11 +111,8 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     ///
     /// # Arguments
     ///
-    /// `stream` - The stream to read the input from and write the output to.
-    /// `request_id` - The request ID to be placed in the message header.
+    /// `collection` - The collection to read from.
     /// `flags` - Bit vector of query options.
-    /// `namespace` - The full qualified name of the collection, beginning with
-    ///               the database name and a dot.
     /// `number_to_skip` - The number of initial documents to skip over in the
     ///                    query results.
     /// `number_to_return - The total number of documents that should be
@@ -136,13 +126,12 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     ///
     /// Returns the cursor for the query results on success, or an error string
     /// on failure.
-    pub fn query(stream: &'a mut T, request_id: i32, flags: OpQueryFlags,
-                 namespace: &str, number_to_skip: i32,
-                 number_to_return: i32, query: bson::Document,
-                 return_field_selector: Option<bson::Document>) -> Result<Cursor<'a, T>, String> {
-
-        Cursor::query_with_batch_size(stream, 20, request_id, flags,
-                                      namespace, number_to_skip,
+    pub fn query(collection: &'a Collection<'a>, flags: OpQueryFlags,
+                 number_to_skip: i32, number_to_return: i32, query: bson::Document,
+                 return_field_selector: Option<bson::Document>) -> Result<Cursor<'a>, String> {
+        
+        Cursor::query_with_batch_size(collection, 20, flags,
+                                      number_to_skip,
                                       number_to_return, query,
                                       return_field_selector)
     }
@@ -153,8 +142,8 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     ///
     /// Returns the newly-created method.
     fn new_get_more_request(&mut self) -> Message {
-        Message::with_get_more(self.request_id,
-                               self.namespace.to_owned(),
+        Message::with_get_more(self.collection.get_req_id(),
+                               self.collection.namespace.to_owned(),
                                self.batch_size, self.cursor_id)
     }
 
@@ -167,17 +156,21 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     fn next_from_stream(&mut self) -> Option<bson::Document> {
         let get_more = self.new_get_more_request();
 
-        match get_more.write(&mut self.stream) {
-            Ok(_) => (),
-            Err(_) => return None
+        let socket = match self.collection.db.client.socket.lock() {
+            Ok(val) => val,
+            Err(_) => return None,
         };
 
-        let reply = match Message::read(&mut self.stream) {
+        if get_more.write(&mut *socket.borrow_mut()).is_err() {
+            return None;
+        }
+
+        let reply = match Message::read(&mut *socket.borrow_mut()) {
             Ok(m) => m,
             Err(_) => return None
         };
 
-        match Cursor::<T>::get_bson_and_cid_from_message(reply) {
+        match Cursor::get_bson_and_cid_from_message(reply) {
             Some((v, _)) => {
                 self.buffer.extend(v);
                 self.buffer.pop_front()
@@ -222,7 +215,7 @@ impl <'a, T> Cursor<'a, T> where T: Read + Write + 'a {
     }
 }
 
-impl <'a, T> Iterator for Cursor<'a, T> where T: Read + Write + 'a {
+impl <'a> Iterator for Cursor<'a> {
     type Item = bson::Document;
 
     /// Attempts to read a BSON document from the cursor.

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -53,9 +53,11 @@ fn cursor_features() {
         _ => panic!("Wrong value returned from Cursor#next")
     };
 
+    assert!(cursor.has_next());
     let vec = cursor.next_n(20);
 
     assert_eq!(vec.len(), 6 as usize);
+    assert!(!cursor.has_next());
 
     for i in 0..vec.len() {
         match vec[i].get("foo") {

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -1,82 +1,66 @@
 use bson::Document;
-use bson::Bson::{FloatingPoint, I64};
-use bson::Bson::String as BsonString;
+use bson::Bson::I64;
+
+use mongodb::client::MongoClient;
 use mongodb::client::cursor::Cursor;
-use mongodb::client::wire_protocol::flags::{OpInsertFlags, OpQueryFlags};
-use mongodb::client::wire_protocol::operations::Message;
-use std::io::Write;
-use std::net::TcpStream;
+use mongodb::client::wire_protocol::flags::OpQueryFlags;
 
 #[test]
 fn cursor_features() {
-    match TcpStream::connect("localhost:27017") {
-        Ok(mut stream) => {
-            let docs : Vec<_> = (0..10).map(|i| {
-                let mut doc = Document::new();
-                doc.insert("foo".to_owned(), I64(i));
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+    let coll = db.collection("cursor_test");
 
-                doc
-            }).collect();
+    db.drop_database().ok().expect("Failed to drop database.");
 
-            let flags = OpInsertFlags::no_flags();
-            let name = "test.cursor_test".to_owned();
-            let res = Message::with_insert(1, flags, name, docs);
+    let docs : Vec<_> = (0..10).map(|i| {
+        let mut doc = Document::new();
+        doc.insert("foo".to_owned(), I64(i));
+        doc
+    }).collect();
 
-            let cm = match res {
-                Ok(message) => message,
-                Err(_) => panic!("Could not create insert message!")
-            };
+    assert!(coll.insert_many(docs, false, None).is_ok());
 
-            match cm.write(&mut stream) {
-                Ok(_) => (),
-                Err(s) => panic!("{}", s)
-            };
+    let doc = Document::new();
+    let flags = OpQueryFlags::no_flags();
 
-            let doc = Document::new();
-            let flags = OpQueryFlags::no_flags();
-            let name = "test.cursor_test";
-            let result = Cursor::query_with_batch_size(&mut stream, 3, 2, flags,
-                                                       name, 0, 0, doc, None);
+    let result = Cursor::query_with_batch_size(&coll, 3, flags,
+                                               0, 0, doc, None);
 
-            let mut cursor = match result {
-                Ok(c) => c,
-                Err(s) => panic!("{}", s)
-            };
+    let mut cursor = match result {
+        Ok(c) => c,
+        Err(s) => panic!("{}", s)
+    };
 
-            let batch = cursor.next_batch();
+    let batch = cursor.next_batch();
 
-            assert_eq!(batch.len(), 3 as usize);
+    assert_eq!(batch.len(), 3 as usize);
 
-            for i in 0..batch.len() {
-                match batch[i].get("foo") {
-                    Some(&I64(j)) => assert_eq!(i as i64, j),
-                    _ => panic!("Wrong value returned from Cursor#next_batch")
-                };
-            }
+    for i in 0..batch.len() {
+        match batch[i].get("foo") {
+            Some(&I64(j)) => assert_eq!(i as i64, j),
+            _ => panic!("Wrong value returned from Cursor#next_batch")
+        };
+    }
 
-            let bson = match cursor.next() {
-                Some(b) => b,
-                None => panic!("Nothing returned from Cursor#next")
-            };
+    let bson = match cursor.next() {
+        Some(b) => b,
+        None => panic!("Nothing returned from Cursor#next")
+    };
 
-            match bson.get("foo") {
-                Some(&I64(3)) => (),
-                _ => panic!("Wrong value returned from Cursor#next")
-            };
+    match bson.get("foo") {
+        Some(&I64(3)) => (),
+        _ => panic!("Wrong value returned from Cursor#next")
+    };
 
-            let vec = cursor.next_n(20);
+    let vec = cursor.next_n(20);
 
-            assert_eq!(vec.len(), 6 as usize);
+    assert_eq!(vec.len(), 6 as usize);
 
-            for i in 0..vec.len() {
-                match vec[i].get("foo") {
-                    Some(&I64(j)) => assert_eq!(4 + i as i64 , j),
-                    _ => panic!("Wrong value returned from Cursor#next_batch")
-                };
-            }
-        },
-        Err(_) => {
-            panic!("Could not connect to server")
-        }
+    for i in 0..vec.len() {
+        match vec[i].get("foo") {
+            Some(&I64(j)) => assert_eq!(4 + i as i64 , j),
+            _ => panic!("Wrong value returned from Cursor#next_batch")
+        };
     }
 }


### PR DESCRIPTION
Modifies cursors to contain Collection refs. `find` and `find_one` now return cursors.

Fixes #50.