### PR TITLE
Basic RunCommands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 
-before_script:
+before_install:
     - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.3.tgz
     - tar xvf mongodb-linux-x86_64-3.0.3.tgz
     - mv mongodb-linux-x86_64-3.0.3 3.0.3
@@ -9,7 +9,8 @@ env:
     - RUST_TEST_THREADS=1
 
 script:
-    - mkdir -p ./data/db
-    - 3.0.3/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog
+    - mkdir -p ./data/db ./data/test
+    - 3.0.3/bin/mongod --fork --nopreallocj --dbpath ./data/db --syslog --port 27017
+    - 3.0.3/bin/mongod --fork --nopreallocj --dbpath ./data/test --syslog --port 27018
     - cargo build --verbose
     - cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,14 +2,14 @@
 name = "mongodb"
 version = "0.1.0"
 dependencies = [
- "bson 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bson 0.1.0 (git+https://github.com/kyeah/bson-rs)",
  "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bson"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.0"
+source = "git+https://github.com/kyeah/bson-rs#af061a4a4f06cc522c6796b3e361b8938bd19142"
 dependencies = [
  "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,7 @@ authors = ["Valeri Karpov <valkar207@gmail.com>",
 
 [dependencies]
 byteorder = "0.3.10"
-bson = "0.1.1"
+
+[dependencies.bson]
+git="https://github.com/kyeah/bson-rs"
+ref="af061a4a4f06cc522c6796b3e361b8938bd19142"

--- a/src/client/coll/mod.rs
+++ b/src/client/coll/mod.rs
@@ -201,7 +201,9 @@ impl<'a> Collection<'a> {
         updates.insert("q".to_owned(), Bson::Document(filter));
         updates.insert("u".to_owned(), Bson::Document(update));
         updates.insert("upsert".to_owned(), Bson::Boolean(upsert));
-        updates.insert("multi".to_owned(), Bson::Boolean(multi));
+        if multi {
+            updates.insert("multi".to_owned(), Bson::Boolean(multi));
+        }
 
         let mut cmd = bson::Document::new();
         cmd.insert("update".to_owned(), Bson::String(self.name()));

--- a/src/client/coll/mod.rs
+++ b/src/client/coll/mod.rs
@@ -79,15 +79,17 @@ impl<'a> Collection<'a> {
     }
 
     /// Returns a list of documents within the collection that match the filter.
-    pub fn find(&'a self, filter: Option<bson::Document>, options: Option<FindOptions>)
+    pub fn find(&self, filter: Option<bson::Document>, options: Option<FindOptions>)
                 -> Result<Cursor<'a>, String> {
 
         let doc = filter.unwrap_or(bson::Document::new());
         let options = options.unwrap_or(FindOptions::new());
         let flags = OpQueryFlags::with_find_options(&options);
 
-        Cursor::query_with_batch_size(self, options.batch_size, flags, options.skip as i32,
-                                      options.limit, doc, options.projection)
+        Cursor::query_with_batch_size(&self.db.client, self.namespace.to_owned(),
+                                      options.batch_size, flags, options.skip as i32,
+                                      options.limit, doc, options.projection.clone(),
+                                      options.is_cmd_cursor())
     }
 
     /// Returns the first document within the collection that matches the filter, or None.
@@ -137,8 +139,8 @@ impl<'a> Collection<'a> {
         cmd.insert("ordered".to_owned(), Bson::Boolean(ordered));
         cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
 
-        let res = try!(self.db.command(cmd));
-        match res {
+        let result = try!(self.db.command(cmd));
+        match result {
             Some(doc) => Ok(doc),
             None => Err("Insertion reply not received from server.".to_owned()),
         }
@@ -172,8 +174,8 @@ impl<'a> Collection<'a> {
         cmd.insert("deletes".to_owned(), Bson::Array(vec!(Bson::Document(deletes))));
         cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
 
-        let res = try!(self.db.command(cmd));
-        match res {
+        let result = try!(self.db.command(cmd));
+        match result {
             Some(doc) => Ok(DeleteResult::new(doc)),
             None => Err("Delete reply not received from server.".to_owned()),
         }
@@ -206,8 +208,8 @@ impl<'a> Collection<'a> {
         cmd.insert("updates".to_owned(), Bson::Array(vec!(Bson::Document(updates))));
         cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
 
-        let res = try!(self.db.command(cmd));
-        match res {
+        let result = try!(self.db.command(cmd));
+        match result {
             Some(doc) => Ok(UpdateResult::new(doc)),
             None => Err("delete_many reply not received from server.".to_owned()),
         }

--- a/src/client/coll/mod.rs
+++ b/src/client/coll/mod.rs
@@ -89,7 +89,7 @@ impl<'a> Collection<'a> {
         Cursor::query_with_batch_size(&self.db.client, self.namespace.to_owned(),
                                       options.batch_size, flags, options.skip as i32,
                                       options.limit, doc, options.projection.clone(),
-                                      options.is_cmd_cursor())
+                                      false)
     }
 
     /// Returns the first document within the collection that matches the filter, or None.

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -89,6 +89,7 @@ pub struct FindOptions {
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
     pub read_preference: Option<ReadPreference>,
+    is_cmd_cursor: bool,
 }
 
 /// Options for findOneAndDelete operations.
@@ -136,7 +137,18 @@ impl FindOptions {
             projection: None,
             sort: None,
             read_preference: None,
+            is_cmd_cursor: false,
         }
+    }
+
+    pub fn with_cmd_cursor() -> FindOptions {
+        let mut opts = FindOptions::new();
+        opts.is_cmd_cursor = true;
+        opts
+    }
+
+    pub fn is_cmd_cursor(&self) -> bool {
+        self.is_cmd_cursor
     }
 
     /// Clone the current options struct with a new limit.

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -89,7 +89,6 @@ pub struct FindOptions {
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
     pub read_preference: Option<ReadPreference>,
-    is_cmd_cursor: bool,
 }
 
 /// Options for findOneAndDelete operations.
@@ -137,18 +136,7 @@ impl FindOptions {
             projection: None,
             sort: None,
             read_preference: None,
-            is_cmd_cursor: false,
         }
-    }
-
-    pub fn with_cmd_cursor() -> FindOptions {
-        let mut opts = FindOptions::new();
-        opts.is_cmd_cursor = true;
-        opts
-    }
-
-    pub fn is_cmd_cursor(&self) -> bool {
-        self.is_cmd_cursor
     }
 
     /// Clone the current options struct with a new limit.

--- a/src/client/coll/results.rs
+++ b/src/client/coll/results.rs
@@ -7,12 +7,12 @@ use std::collections::BTreeMap;
 #[derive(Clone)]
 pub struct BulkWriteResult {
     pub acknowledged: bool,
-    pub inserted_count: i64,
+    pub inserted_count: i32,
     pub inserted_ids: Option<BTreeMap<i64, Bson>>,
-    pub matched_count: i64,
-    pub modified_count: i64,
-    pub deleted_count: i64,
-    pub upserted_count: i64,
+    pub matched_count: i32,
+    pub modified_count: i32,
+    pub deleted_count: i32,
+    pub upserted_count: i32,
     pub upserted_ids: BTreeMap<i64, Bson>,
 }
 
@@ -34,15 +34,15 @@ pub struct InsertManyResult {
 #[derive(Clone)]
 pub struct DeleteResult {
     pub acknowledged: bool,
-    pub deleted_count: i64,
+    pub deleted_count: i32,
 }
 
 /// Results for an update operation.
 #[derive(Clone)]
 pub struct UpdateResult {
     pub acknowledged: bool,
-    pub matched_count: i64,
-    pub modified_count: i64,
+    pub matched_count: i32,
+    pub modified_count: i32,
     pub upserted_id: Option<Bson>,
 }
 
@@ -70,7 +70,7 @@ impl DeleteResult {
     /// Extracts server reply information into a result.
     pub fn new(doc: bson::Document) -> DeleteResult {
         let n = match doc.get("n") {
-            Some(&Bson::I64(n)) => n,
+            Some(&Bson::I32(n)) => n,
             _ => 0,
         };
 
@@ -85,12 +85,12 @@ impl UpdateResult {
     /// Extracts server reply information into a result.
     pub fn new(doc: bson::Document) -> UpdateResult {
         let n = match doc.get("n") {
-            Some(&Bson::I64(n)) => n,
+            Some(&Bson::I32(n)) => n,
             _ => 0,
         };
 
         let n_modified = match doc.get("nModified") {
-            Some(&Bson::I64(n)) => n,
+            Some(&Bson::I32(n)) => n,
             _ => 0,
         };
 

--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -1,6 +1,7 @@
 use bson;
+use bson::Bson;
 
-use client::coll::Collection;
+use client::MongoClient;
 
 use client::wire_protocol::flags::OpQueryFlags;
 use client::wire_protocol::operations::Message;
@@ -19,12 +20,14 @@ pub const DEFAULT_BATCH_SIZE: i32 = 20;
 /// `batch_size` - How many documents to fetch at a given time from the server.
 /// `cursor_id` - Uniquely identifies the cursor being returned by the reply.
 pub struct Cursor<'a> {
-    collection: &'a Collection<'a>,
+    client: &'a MongoClient,
+    namespace: String,
     batch_size: i32,
     cursor_id: i64,
     limit: i32,
     count: i32,
     buffer: VecDeque<bson::Document>,
+    is_cmd_cursor: bool,
 }
 
 impl <'a> Cursor<'a> {
@@ -45,6 +48,7 @@ impl <'a> Cursor<'a> {
                 let mut v = VecDeque::new();
 
                 for doc in docs {
+                    println!("{}", Bson::Document(doc.clone()).to_json());
                     v.push_back(doc.clone());
                 }
 
@@ -53,6 +57,37 @@ impl <'a> Cursor<'a> {
             _ => None
         }
     }
+
+    fn get_bson_and_cid_from_command_message(message: Message) -> Option<(VecDeque<bson::Document>, i64)> {
+        match Cursor::get_bson_and_cid_from_message(message) {
+            Some((v, cid)) => {
+                if v.len() != 1 {
+                    return None;
+                }
+
+                let ref doc = v[0];
+                if let Some(&Bson::Document(ref cursor)) = doc.get("cursor") {
+                    if let Some(&Bson::Array(ref batch)) = cursor.get("firstBatch") {
+                        let map = batch.iter().filter_map(|bdoc| {
+                            if let &Bson::Document(ref doc) = bdoc {
+                                Some(doc.clone())
+                            } else {
+                                None
+                            }
+                        }).collect();
+                        return Some((map, cid));
+                    }
+                }
+                None
+            },
+            None => None,
+        }
+    }
+
+    //    pub fn command_query(collection: &'a Collection<'a>,
+    //                         cmd: bson::Document) -> Result<Cursor<'a>, String> {
+
+    //    }
 
     /// Executes a query where the batch size of the returned cursor is
     /// specified.
@@ -74,18 +109,21 @@ impl <'a> Cursor<'a> {
     ///
     /// Returns the cursor for the query results on success, or an error string
     /// on failure.
-    pub fn query_with_batch_size(collection: &'a Collection<'a>,
-                                 batch_size: i32,
-                                 flags: OpQueryFlags,
-                                 number_to_skip: i32, number_to_return: i32,
-                                 query: bson::Document,
-                                 return_field_selector: Option<bson::Document>) -> Result<Cursor<'a>, String> {
-        let result = Message::with_query(collection.get_req_id(), flags,
-                                         collection.namespace.to_owned(),
-                                         number_to_skip, number_to_return,
-                                         query, return_field_selector);
+    pub fn query_with_batch_size<'b>(client: &'a MongoClient,
+                                     namespace: String,
+                                     batch_size: i32,
+                                     flags: OpQueryFlags,
+                                     number_to_skip: i32, number_to_return: i32,
+                                     query: bson::Document,
+                                     return_field_selector: Option<bson::Document>,
+                                     is_cmd_cursor: bool) -> Result<Cursor<'a>, String> {
 
-        let socket = match collection.db.client.socket.lock() {
+        let result = Message::with_query(client.get_req_id(), flags,
+                                         namespace.to_owned(),
+                                         number_to_skip, batch_size,
+                                         query.clone(), return_field_selector);
+
+        let socket = match client.socket.lock() {
             Ok(val) => val,
             Err(_) => return Err("Socket lock is poisoned.".to_owned()),
         };
@@ -94,14 +132,22 @@ impl <'a> Cursor<'a> {
         try!(message.write(&mut *socket.borrow_mut()));
         let reply = try!(Message::read(&mut *socket.borrow_mut()));
 
-        match Cursor::get_bson_and_cid_from_message(reply) {
+        let res = if is_cmd_cursor {
+            Cursor::get_bson_and_cid_from_command_message(reply)
+        } else {
+            Cursor::get_bson_and_cid_from_message(reply)
+        };
+
+        match res {
             Some((buf, cursor_id)) => Ok(Cursor {
-                collection: collection,
+                client: client,
+                namespace: namespace,
                 batch_size: batch_size,
                 cursor_id: cursor_id,
                 limit: number_to_return,
                 count: 0,
                 buffer: buf,
+                is_cmd_cursor: is_cmd_cursor,
             }),
             None => Err("Invalid response received".to_owned()),
         }
@@ -126,14 +172,15 @@ impl <'a> Cursor<'a> {
     ///
     /// Returns the cursor for the query results on success, or an error string
     /// on failure.
-    pub fn query(collection: &'a Collection<'a>, flags: OpQueryFlags,
-                 number_to_skip: i32, number_to_return: i32, query: bson::Document,
-                 return_field_selector: Option<bson::Document>) -> Result<Cursor<'a>, String> {
+    pub fn query(client: &'a MongoClient, namespace: String,
+                 flags: OpQueryFlags, number_to_skip: i32, number_to_return: i32,
+                 query: bson::Document, return_field_selector: Option<bson::Document>,
+                 is_cmd_cursor: bool) -> Result<Cursor<'a>, String> {
 
-        Cursor::query_with_batch_size(collection, DEFAULT_BATCH_SIZE, flags,
+        Cursor::query_with_batch_size(client, namespace, DEFAULT_BATCH_SIZE, flags,
                                       number_to_skip,
                                       number_to_return, query,
-                                      return_field_selector)
+                                      return_field_selector, is_cmd_cursor)
     }
 
     /// Helper method to create a "get more" request.
@@ -142,14 +189,14 @@ impl <'a> Cursor<'a> {
     ///
     /// Returns the newly-created method.
     fn new_get_more_request(&mut self) -> Message {
-        Message::with_get_more(self.collection.get_req_id(),
-                               self.collection.namespace.to_owned(),
+        Message::with_get_more(self.client.get_req_id(),
+                               self.namespace.to_owned(),
                                self.batch_size, self.cursor_id)
     }
 
     /// Attempts to read another batch of BSON documents from the stream.
     fn get_from_stream(&mut self) -> Result<(), String> {
-        let socket = match self.collection.db.client.socket.lock() {
+        let socket = match self.client.socket.lock() {
             Ok(val) => val,
             Err(_) => return Err("Socket lock is poisoned.".to_owned()),
         };
@@ -214,7 +261,7 @@ impl <'a> Cursor<'a> {
     }
 
     pub fn has_next(&mut self) -> bool {
-        if self.limit > 0 && self.count >= self.limit {
+        if self.limit > 0 && self.count >= self.limit && !self.is_cmd_cursor {
             false
         } else {
             if self.buffer.is_empty() && self.limit != 1 {

--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -277,7 +277,7 @@ impl <'a> Cursor<'a> {
         if self.limit > 0 && self.count >= self.limit {
             false
         } else {
-            if self.buffer.is_empty() && self.limit != 1 && !self.is_cmd_cursor {
+            if self.buffer.is_empty() && self.limit != 1 && self.cursor_id != 0 {
                 self.get_from_stream();
             }
             !self.buffer.is_empty()

--- a/src/client/db.rs
+++ b/src/client/db.rs
@@ -54,11 +54,8 @@ impl<'a> Database<'a> {
     }
 
     /// Sends an administrative command over find_one.
-    pub fn command_cursor(&'a self, spec: bson::Document) -> Result<Cursor, String> {
-        let coll = self.collection("$cmd");
-        let mut options = FindOptions::with_cmd_cursor();
-        options.batch_size = 1;
-        coll.find(Some(spec), Some(options))
+    pub fn command_cursor(&self, spec: bson::Document) -> Result<Cursor, String> {
+        Cursor::command_cursor(self.client, &self.name[..], spec)
     }
 
     pub fn command(&'a self, spec: bson::Document) -> Result<Option<bson::Document>, String> {

--- a/src/client/db.rs
+++ b/src/client/db.rs
@@ -2,7 +2,9 @@ use bson;
 use bson::Bson;
 use client::MongoClient;
 use client::coll::Collection;
+use client::coll::options::FindOptions;
 use client::common::{ReadPreference, WriteConcern};
+use client::cursor::Cursor;
 
 /// Interfaces with a MongoDB database.
 pub struct Database<'a> {
@@ -52,51 +54,44 @@ impl<'a> Database<'a> {
     }
 
     /// Sends an administrative command over find_one.
+    pub fn command_cursor(&'a self, spec: bson::Document) -> Result<Cursor, String> {
+        let coll = self.collection("$cmd");
+        let mut options = FindOptions::with_cmd_cursor();
+        options.batch_size = 1;
+        coll.find(Some(spec), Some(options))
+    }
+
     pub fn command(&'a self, spec: bson::Document) -> Result<Option<bson::Document>, String> {
-        let coll = Collection::new(self, "$cmd", false, None, None);
-        coll.find_one(Some(spec), None)
+        let coll = self.collection("$cmd");
+        let mut options = FindOptions::new();
+        options.batch_size = 1;
+        coll.find_one(Some(spec), Some(options))
     }
 
     /// Returns a list of collections within the database.
-    pub fn list_collections(&'a self) -> Result<Vec<Collection<'a>>, String> {
+    pub fn list_collections(&'a self, filter: Option<bson::Document>) -> Result<Cursor, String> {
         let mut spec = bson::Document::new();
         spec.insert("listCollections".to_owned(), Bson::I32(1));
-        let res = try!(self.command(spec));
-
-        if res.is_none() {
-            return Ok(vec!());
+        if filter.is_some() {
+            spec.insert("filter".to_owned(), Bson::Document(filter.unwrap()));
         }
 
-        let bson = res.unwrap();
-
-        // Wire/Client proof of concept; replace this with cursor implementation in the future.
-        // Unwrap reply
-        if let Some(&Bson::Document(ref cursor)) = bson.get("cursor") {
-            // Unwrap batched results
-            if let Some(&Bson::Array(ref batch)) = cursor.get("firstBatch") {
-                // Iterate over each collection returned
-                let mut collections = Vec::new();
-                for bdoc in batch {
-                    // Unwrap document
-                    if let &Bson::Document(ref doc) = bdoc {
-                        // Unwrap name
-                        if let Some(&Bson::String(ref name)) = doc.get("name") {
-                            // Push collection into returned results
-                            collections.push(Collection::new(self, &name[..], false, None, None));
-                        }
-                    }
-                };
-                return Ok(collections);
-            }
-        }
-
-        Err("Unable to unwrap collections list.".to_owned())
+        let mut cursor = try!(self.command_cursor(spec));
+        Ok(cursor)
     }
 
     /// Returns a list of collection names within the database.
-    pub fn collection_names(&'a self) -> Result<Vec<String>, String> {
-        let results = try!(self.list_collections());
-        Ok(results.iter().map(|coll| coll.name()).collect())
+    pub fn collection_names(&'a self, filter: Option<bson::Document>) -> Result<Vec<String>, String> {
+        let mut cursor = try!(self.list_collections(filter));
+        let mut results = Vec::new();
+        loop {
+            match cursor.next() {
+                Some(doc) => if let Some(&Bson::String(ref name)) = doc.get("name") {
+                    results.push(name.to_owned());
+                },
+                None => return Ok(results),
+            }
+        }
     }
 
     /// Creates a new collection.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -5,6 +5,9 @@ pub mod connstring;
 pub mod cursor;
 pub mod wire_protocol;
 
+use bson;
+use bson::Bson;
+
 use std::cell::RefCell;
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
@@ -13,6 +16,7 @@ use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
 use client::db::Database;
 use client::common::{ReadPreference, WriteConcern};
 use client::connstring::ConnectionString;
+use client::cursor::Cursor;
 
 /// Interfaces with a MongoDB server or replica set.
 pub struct MongoClient {
@@ -100,11 +104,30 @@ impl MongoClient {
             Err(_) => return Err(format!("Failed to connect to host '{}:{}'", host_name, port)),
         }
     }
-
+    
     /// Drops the database defined by `db_name`.
     pub fn drop_database(&self, db_name: &str) -> Result<(), String> {
-        let db = Database::new(self, db_name, None, None);
+        let db = self.db(db_name);
         try!(db.drop_database());
         Ok(())
+    }
+
+    /// Reports whether this instance is a primary, master, mongos, or standalone mongod instance.
+    pub fn is_master(&self) -> Result<bool, String> {
+        let mut doc = bson::Document::new();
+        doc.insert("isMaster".to_owned(), Bson::I32(1));
+
+        let db = self.db("local");
+        let res_opt = try!(db.command(doc));
+
+        let res = match res_opt {
+            Some(doc) => doc,
+            None => return Err("No response received from server.".to_owned()),
+        };
+
+        match res.get("ismaster") {
+            Some(&Bson::Boolean(is_master)) => Ok(is_master),
+            _ => Err("Unexpected bson response".to_owned()),
+        }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -111,7 +111,21 @@ impl MongoClient {
         doc.insert("listDatabases".to_owned(), Bson::I32(1));
         Cursor::command_cursor(self, "admin", doc)
     }
-    
+
+    /// Returns a list of all database names that exist on the server.
+    pub fn database_names(&self) -> Result<Vec<String>, String> {
+        let mut cursor = try!(self.list_databases());
+        let mut results = Vec::new();
+        loop {
+            match cursor.next() {
+                Some(doc) => if let Some(&Bson::String(ref name)) = doc.get("name") {
+                    results.push(name.to_owned());
+                },
+                None => return Ok(results),
+            }
+        }
+    }
+
     /// Drops the database defined by `db_name`.
     pub fn drop_database(&self, db_name: &str) -> Result<(), String> {
         let db = self.db(db_name);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -104,6 +104,13 @@ impl MongoClient {
             Err(_) => return Err(format!("Failed to connect to host '{}:{}'", host_name, port)),
         }
     }
+
+    /// Provides an iterator over the server's database information.
+    pub fn list_databases(&self) -> Result<Cursor, String> {
+        let mut doc = bson::Document::new();
+        doc.insert("listDatabases".to_owned(), Bson::I32(1));
+        Cursor::command_cursor(self, "admin", doc)
+    }
     
     /// Drops the database defined by `db_name`.
     pub fn drop_database(&self, db_name: &str) -> Result<(), String> {

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -16,7 +16,7 @@ fn list_databases() {
 #[test]
 fn database_names() {
     let client = MongoClient::with_uri("mongodb://localhost:27018").unwrap();
-    let mut results = client.database_names().ok().expect("Failed to execute database_names.");
+    let results = client.database_names().ok().expect("Failed to execute database_names.");
     assert_eq!(1, results.len());
     assert_eq!("local", results[0]);
 }

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -1,0 +1,21 @@
+use bson::Bson;
+use mongodb::client::MongoClient;
+
+#[test]
+fn list_databases() {
+    let client = MongoClient::with_uri("mongodb://localhost:27018").unwrap();
+    let mut cursor = client.list_databases().ok().expect("Failed to execute list_databases.");
+    let results = cursor.next_n(3);
+    assert_eq!(1, results.len());
+    match results[0].get("name") {
+        Some(&Bson::String(ref name)) => assert_eq!("local", name),
+        _ => panic!("Expected name string!"),
+    }
+}
+
+#[test]
+fn is_master() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let res = client.is_master().ok().expect("Failed to execute is_master.");
+    assert!(res);
+}

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -26,10 +26,11 @@ fn database_names() {
     // Check new dbs
     let results = client.database_names().ok().expect("Failed to execute database_names.");
     assert_eq!(3, results.len());
-    assert_eq!("local", results[0]);
-    assert_eq!("new_db", results[1]);
-    assert_eq!("new_db_2", results[2]);
+    assert!(results.contains(&"local".to_owned()));
+    assert!(results.contains(&"new_db".to_owned()));
+    assert!(results.contains(&"new_db_2".to_owned()));
 }
+
 
 #[test]
 fn is_master() {

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -14,6 +14,14 @@ fn list_databases() {
 }
 
 #[test]
+fn database_names() {
+    let client = MongoClient::with_uri("mongodb://localhost:27018").unwrap();
+    let mut results = client.database_names().ok().expect("Failed to execute database_names.");
+    assert_eq!(1, results.len());
+    assert_eq!("local", results[0]);
+}
+
+#[test]
 fn is_master() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
     let res = client.is_master().ok().expect("Failed to execute is_master.");

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -67,17 +67,23 @@ fn list_collections() {
         .ok().expect("Failed to insert placeholder document into collection");
 
     // Check for namespaces
-    let result = db.list_collections().ok().expect("Failed to execute list_collections command.");;
-    assert_eq!(3, result.len());
+    let mut cursor = db.list_collections(None)
+        .ok().expect("Failed to execute list_collections command.");;
+
+    let results = cursor.next_n(3);
+    assert_eq!(3, results.len());
 
     let namespace = vec!(
-        "test.system.indexes",
-        "test.test",
-        "test.test2",
+        "system.indexes",
+        "test",
+        "test2",
         );
 
     for i in 0..2 {
-        assert_eq!(namespace[i], result[i].namespace);
+        match results[i].get("name") {
+            Some(&Bson::String(ref name)) => assert_eq!(namespace[i], name),
+            _ => panic!("Expected BSON string!"),
+        }
     }
 }
 

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -54,40 +54,6 @@ fn find_and_insert_one() {
 }
 
 #[test]
-fn list_collections() {
-    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
-    let db = client.db("test");
-
-    db.drop_database().ok().expect("Failed to drop database");
-
-    // Build collections
-    db.collection("test").insert_one(bson::Document::new(), None)
-        .ok().expect("Failed to insert placeholder document into collection");
-    db.collection("test2").insert_one(bson::Document::new(), None)
-        .ok().expect("Failed to insert placeholder document into collection");
-
-    // Check for namespaces
-    let mut cursor = db.list_collections(None)
-        .ok().expect("Failed to execute list_collections command.");;
-
-    let results = cursor.next_n(3);
-    assert_eq!(3, results.len());
-
-    let namespace = vec!(
-        "system.indexes",
-        "test",
-        "test2",
-        );
-
-    for i in 0..2 {
-        match results[i].get("name") {
-            Some(&Bson::String(ref name)) => assert_eq!(namespace[i], name),
-            _ => panic!("Expected BSON string!"),
-        }
-    }
-}
-
-#[test]
 fn insert_many() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
     let db = client.db("test");
@@ -109,17 +75,13 @@ fn insert_many() {
     assert_eq!(2, results.len());
 
     // Assert expected title of documents
-    let expected_titles = vec!(
-        "Jaws",
-        "Back to the Future",
-        );
-
-    for i in 0..1 {
-        let ref expected_title = expected_titles[i];
-        match results[i].get("title") {
-            Some(&Bson::String(ref title)) => assert_eq!(expected_title, title),
-            _ => panic!("Expected Bson::String!"),
-        };
+    match results[0].get("title") {
+        Some(&Bson::String(ref title)) => assert_eq!("Jaws", title),
+        _ => panic!("Expected Bson::String!"),
+    }
+    match results[1].get("title") {
+        Some(&Bson::String(ref title)) => assert_eq!("Back to the Future", title),
+        _ => panic!("Expected Bson::String!"),
     }
 }
 
@@ -209,19 +171,18 @@ fn replace_one() {
     assert_eq!(3, results.len());
 
     // Assert expected title of documents
-    let expected_titles = vec!(
-        "Jaws",
-        "12 Angry Men",
-        "12 Angry Men",
-        );
-
-    for i in 0..1 {
-        let ref expected_title = expected_titles[i];
-        match results[i].get("title") {
-            Some(&Bson::String(ref title)) => assert_eq!(expected_title, title),
-            _ => panic!("Expected Bson::String!"),
-        };
-    }
+    match results[0].get("title") {
+        Some(&Bson::String(ref title)) => assert_eq!("Jaws", title),
+        _ => panic!("Expected Bson::String!"),
+    };
+    match results[1].get("title") {
+        Some(&Bson::String(ref title)) => assert_eq!("12 Angry Men", title),
+        _ => panic!("Expected Bson::String!"),
+    };
+    match results[2].get("title") {
+        Some(&Bson::String(ref title)) => assert_eq!("12 Angry Men", title),
+        _ => panic!("Expected Bson::String!"),
+    };
 }
 
 #[test]
@@ -297,7 +258,6 @@ fn update_many() {
 
     // Assert director attributes
     for i in 0..3 {
-
         // Check title
         match results[i].get("title") {
             Some(&Bson::String(ref title)) => {

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -201,7 +201,7 @@ fn update_one() {
     doc.insert("title".to_owned(), Bson::String("Jaws".to_owned()));
     doc2.insert("title".to_owned(), Bson::String("Back to the Future".to_owned()));
     doc3.insert("title".to_owned(), Bson::String("12 Angry Men".to_owned()));
-    coll.insert_many(vec!(doc.clone(), doc2.clone(), doc3.clone()), false, None)
+    coll.insert_many(vec!(doc.clone(), doc2.clone(), doc3.clone(), doc2.clone()), false, None)
         .ok().expect("Failed to insert documents into collection.");
 
     // Update single document
@@ -257,23 +257,16 @@ fn update_many() {
     assert_eq!(4, results.len());
 
     // Assert director attributes
-    for i in 0..3 {
-        // Check title
-        match results[i].get("title") {
-            Some(&Bson::String(ref title)) => {
-                let dir_opt = results[i].get("director");
+    assert!(results[0].get("director").is_none());
+    assert!(results[2].get("director").is_none());
+    
+    match results[1].get("director") {
+        Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
+        _ => panic!("Expected Bson::String for director!"),
+    }
 
-                // Only doc2 models should have a director field
-                if "Back to the Future" == title {
-                    match dir_opt {
-                        Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
-                        _ => panic!("Expected Bson::String!"),
-                    }
-                } else {
-                    assert!(dir_opt.is_none());
-                }
-            },
-            _ => panic!("Expected Bson::String!"),
-        }
+    match results[3].get("director") {
+        Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
+        _ => panic!("Expected Bson::String for director!"),
     }
 }

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -24,8 +24,9 @@ fn cursor_features() {
     let doc = Document::new();
     let flags = OpQueryFlags::no_flags();
 
-    let result = Cursor::query_with_batch_size(&coll, 3, flags,
-                                               0, 0, doc, None);
+    let result = Cursor::query_with_batch_size(&client, "test.cursor_test".to_owned(),
+                                               3, flags,
+                                               0, 0, doc, None, false);
 
     let mut cursor = match result {
         Ok(c) => c,

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -1,0 +1,33 @@
+#[test]
+fn list_collections() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+
+    db.drop_database().ok().expect("Failed to drop database");
+
+    // Build collections
+    db.collection("test").insert_one(bson::Document::new(), None)
+        .ok().expect("Failed to insert placeholder document into collection");
+    db.collection("test2").insert_one(bson::Document::new(), None)
+        .ok().expect("Failed to insert placeholder document into collection");
+
+    // Check for namespaces
+    let mut cursor = db.list_collections_with_batch_size(None, 1)
+        .ok().expect("Failed to execute list_collections command.");;
+
+    let results = cursor.next_n(5);
+    assert_eq!(3, results.len());
+
+    match results[0].get("name") {
+        Some(&Bson::String(ref name)) => assert_eq!("system.indexes", name),
+        _ => panic!("Expected BSON string!"),
+    }
+    match results[1].get("name") {
+        Some(&Bson::String(ref name)) => assert_eq!("test", name),
+        _ => panic!("Expected BSON string!"),
+    }
+    match results[2].get("name") {
+        Some(&Bson::String(ref name)) => assert_eq!("test2", name),
+        _ => panic!("Expected BSON string!"),
+    }
+}

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -2,3 +2,4 @@ mod coll;
 mod connstring;
 mod cursor;
 mod wire_protocol;
+mod client;


### PR DESCRIPTION
Implements command cursors and modifies the base Cursor implementation to borrow the MongoClient instead of the Collection. Also implements `is_master()` and `database_names()` for clients.

The travis config has been modified to run a clean server on port 27018 under `data/test` for testing `database_names()`.

Successor to #46.