### PR TITLE
Query and Write Op Commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ authors = ["Valeri Karpov <valkar207@gmail.com>",
 byteorder = "0.3.10"
 
 [dependencies.bson]
-git="https://github.com/kyeah/bson-rs"
-ref="af061a4a4f06cc522c6796b3e361b8938bd19142"
+git = "https://github.com/kyeah/bson-rs"
+ref = "af061a4a4f06cc522c6796b3e361b8938bd19142"

--- a/src/client/coll/mod.rs
+++ b/src/client/coll/mod.rs
@@ -96,6 +96,8 @@ impl<'a> Collection<'a> {
         if filter.is_some() {
             spec.insert("query".to_owned(), Bson::Document(filter.unwrap()));
         }
+
+        // Favor specified hint document over string
         if opts.hint_doc.is_some() {
             spec.insert("hint".to_owned(), Bson::Document(opts.hint_doc.unwrap()));
         } else if opts.hint.is_some() {

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -59,10 +59,11 @@ pub struct AggregateOptions {
 /// Options for count queries.
 #[derive(Clone)]
 pub struct CountOptions {
-    pub hint: Option<bson::Document>,
-    pub limit: Option<i64>,
+    pub skip: u64,
+    pub limit: i64,
+    pub hint: Option<String>,
+    pub hint_doc: Option<bson::Document>,
     pub max_time_ms: Option<i64>,
-    pub skip: Option<u64>,
     pub read_preference: Option<ReadPreference>,
 }
 
@@ -117,6 +118,40 @@ pub struct FindOneAndUpdateOptions {
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
     pub upsert: bool,
+}
+
+impl AggregateOptions {
+    pub fn new() -> AggregateOptions {
+        AggregateOptions {
+            allow_disk_use: false,
+            use_cursor: true,
+            batch_size: cursor::DEFAULT_BATCH_SIZE,
+            max_time_ms: None,
+            read_preference: None,
+        }
+    }
+}
+
+impl CountOptions {
+    pub fn new() -> CountOptions {
+        CountOptions {
+            skip: 0,
+            limit: 0,
+            hint: None,
+            hint_doc: None,
+            max_time_ms: None,
+            read_preference: None,
+        }
+    }
+}
+
+impl DistinctOptions {
+    pub fn new() -> DistinctOptions {
+        DistinctOptions {
+            max_time_ms: None,
+            read_preference: None,
+        }
+    }
 }
 
 impl FindOptions {

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -1,6 +1,6 @@
 use bson;
 use client::cursor;
-use client::common::ReadPreference;
+use client::common::{ReadPreference, WriteConcern};
 
 /// Describes the type of cursor to return on collection queries.
 #[derive(Clone, PartialEq, Eq)]
@@ -98,6 +98,7 @@ pub struct FindOneAndDeleteOptions {
     pub max_time_ms: Option<i64>,
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
+    pub write_concern: Option<WriteConcern>,
 }
 
 /// Options for findOneAndReplace operations.
@@ -108,6 +109,7 @@ pub struct FindOneAndReplaceOptions {
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
     pub upsert: bool,
+    pub write_concern: Option<WriteConcern>,
 }
 
 /// Options for findOneAndUpdate operations.
@@ -118,6 +120,7 @@ pub struct FindOneAndUpdateOptions {
     pub projection: Option<bson::Document>,
     pub sort: Option<bson::Document>,
     pub upsert: bool,
+    pub write_concern: Option<WriteConcern>,
 }
 
 impl AggregateOptions {
@@ -188,6 +191,7 @@ impl FindOneAndDeleteOptions {
             max_time_ms: None,
             projection: None,
             sort: None,
+            write_concern: None,
         }
     }
 }
@@ -201,6 +205,7 @@ impl FindOneAndReplaceOptions {
             projection: None,
             sort: None,
             upsert: false,
+            write_concern: None,
         }
     }
 }
@@ -213,6 +218,7 @@ impl FindOneAndUpdateOptions {
             projection: None,
             sort: None,
             upsert: false,
+            write_concern: None,
         }
     }
 }

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -146,3 +146,47 @@ impl FindOptions {
         new_opts
     }
 }
+
+impl FindOneAndDeleteOptions {
+    pub fn new() -> FindOneAndDeleteOptions {
+        FindOneAndDeleteOptions {
+            max_time_ms: None,
+            projection: None,
+            sort: None,
+        }
+    }
+}
+
+
+impl FindOneAndReplaceOptions {
+    pub fn new() -> FindOneAndReplaceOptions {
+        FindOneAndReplaceOptions {
+            return_document: ReturnDocument::Before,
+            max_time_ms: None,
+            projection: None,
+            sort: None,
+            upsert: false,
+        }
+    }
+}
+
+impl FindOneAndUpdateOptions {
+    pub fn new() -> FindOneAndUpdateOptions {
+        FindOneAndUpdateOptions {
+            return_document: ReturnDocument::Before,
+            max_time_ms: None,
+            projection: None,
+            sort: None,
+            upsert: false,
+        }
+    }
+}
+
+impl ReturnDocument {
+    pub fn to_bool(&self) -> bool {
+        match self {
+            &ReturnDocument::Before => false,
+            &ReturnDocument::After => true,
+        }
+    }
+}

--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -28,7 +28,6 @@ pub struct Cursor<'a> {
     limit: i32,
     count: i32,
     buffer: VecDeque<bson::Document>,
-    is_cmd_cursor: bool,
 }
 
 impl <'a> Cursor<'a> {
@@ -67,7 +66,7 @@ impl <'a> Cursor<'a> {
 
     fn get_bson_and_cid_from_command_message(message: Message) -> Option<(VecDeque<bson::Document>, i64, String)> {
         match Cursor::get_bson_and_cid_from_message(message) {
-            Some((v, cid)) => {
+            Some((v, _)) => {
                 if v.len() != 1 {
                     return None;
                 }
@@ -164,7 +163,6 @@ impl <'a> Cursor<'a> {
                 limit: number_to_return,
                 count: 0,
                 buffer: buf,
-                is_cmd_cursor: is_cmd_cursor,
             }),
             None => Err("Invalid response received".to_owned()),
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
 use client::db::Database;
 use client::common::{ReadPreference, WriteConcern};
 use client::connstring::ConnectionString;
-use client::cursor::Cursor;
 
 /// Interfaces with a MongoDB server or replica set.
 pub struct MongoClient {

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -172,7 +172,7 @@ fn find_one_and_update() {
 
     match result.unwrap().get("title") {
         Some(&Bson::String(ref title)) => assert_eq!("Back to the Future", title),
-        _ => panic!("Expected Bson::String!"),        
+        _ => panic!("Expected Bson::String!"),
     }
 
     // Validate state of collection
@@ -186,9 +186,162 @@ fn find_one_and_update() {
     match results[1].get("director") {
         Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
         _ => panic!("Expected Bson::String!"),
-    }    
+    }
 }
 
+#[test]
+fn aggregate() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+    let coll = db.collection("aggregate");
+
+    db.drop_database().ok().expect("Failed to drop database");
+
+    // Insert documents
+    let tags1 = vec![Bson::String("a".to_owned()),
+                     Bson::String("b".to_owned()),
+                     Bson::String("c".to_owned())];
+
+    let tags2 = vec![Bson::String("a".to_owned()),
+                     Bson::String("b".to_owned()),
+                     Bson::String("d".to_owned())];
+
+    let tags3 = vec![Bson::String("d".to_owned()),
+                     Bson::String("e".to_owned()),
+                     Bson::String("f".to_owned())];
+
+    let doc1 = doc! { "tags" => Bson::Array(tags1) };
+    let doc2 = doc! { "tags" => Bson::Array(tags2) };
+    let doc3 = doc! { "tags" => Bson::Array(tags3) };
+
+    coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
+        .ok().expect("Failed to execute insert_many command.");
+
+    // Build aggregation pipeline to count instances of each letter in tag arrays
+    let project = doc! { "$project" => nested_doc! { "tags" => Bson::I32(1) } };
+    let unwind = doc! { "$unwind" => Bson::String("$tags".to_owned()) };
+    let group = doc! { "$group" => nested_doc! {
+        "_id" => Bson::String("$tags".to_owned()),
+        "count" => nested_doc! { "$sum" => Bson::I32(1) }
+    } };
+
+    // Aggregate
+    let mut cursor = coll.aggregate(vec![project, unwind, group], None)
+        .ok().expect("Failed to execute aggregate command.");
+
+    let results = cursor.next_n(10);
+    assert_eq!(6, results.len());
+
+    for i in 0..6 {
+        if let Some(&Bson::String(ref tag)) = results[i].get("_id") {
+            if let Some(&Bson::I32(ref count)) = results[i].get("count") {
+                match &tag[..] {
+                    "a" => assert_eq!(2, *count),
+                    "b" => assert_eq!(2, *count),
+                    "c" => assert_eq!(1, *count),
+                    "d" => assert_eq!(2, *count),
+                    "e" => assert_eq!(1, *count),
+                    "f" => assert_eq!(1, *count),
+                    _ => panic!("Unexpected tag found."),
+                }
+            } else {
+                panic!("Expected Bson::I32 'count'!");
+            }
+        } else {
+            panic!("Expected Bson::String '_id'!");
+        }
+    }
+}
+
+#[test]
+fn count() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+    let coll = db.collection("count");
+
+    db.drop_database().ok().expect("Failed to drop database");
+
+    // Insert documents
+    let doc1 = doc! { "title" => Bson::String("Jaws".to_owned()) };
+    let doc2 = doc! { "title" => Bson::String("Back to the Future".to_owned()) };
+
+    let mut vec = vec![doc1.clone()];
+    for _ in 0..10 {
+        vec.push(doc2.clone());
+    }
+
+    coll.insert_many(vec, false, None).ok().expect("Failed to insert documents.");
+    let count_doc1 = coll.count(Some(doc1), None).ok().expect("Failed to execute count.");
+    assert_eq!(1, count_doc1);
+
+    let count_doc2 = coll.count(Some(doc2), None).ok().expect("Failed to execute count.");
+    assert_eq!(10, count_doc2);
+
+    let count_all = coll.count(None, None).ok().expect("Failed to execute count.");
+    assert_eq!(11, count_all);
+
+    let no_doc = doc! { "title" => Bson::String("Houdini".to_owned()) };
+    let count_none = coll.count(Some(no_doc), None).ok().expect("Failed to execute count.");
+    assert_eq!(0, count_none);
+}
+
+#[test]
+fn distinct() {
+    let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+    let coll = db.collection("distinct");
+
+    db.drop_database().ok().expect("Failed to drop database");
+
+    // Insert documents
+    let doc1 = doc! { "title" => Bson::String("Jaws".to_owned()),
+                       "director" => Bson::String("MB".to_owned()) };
+
+    let doc2 = doc! { "title" => Bson::String("Back to the Future".to_owned()) };
+
+    let doc3 = doc! { "title" => Bson::String("12 Angry Men".to_owned()),
+                       "director" => Bson::String("MB".to_owned()) };
+
+    let mut vec = vec![doc1.clone()];
+    for _ in 0..4 {
+        vec.push(doc2.clone());
+    }
+    for _ in 0..60 {
+        vec.push(doc3.clone());
+    }
+
+    coll.insert_many(vec, false, None).ok().expect("Failed to insert documents.");
+
+    // Distinct titles over all documents
+    let distinct_titles = coll.distinct("title", None, None).ok().expect("Failed to execute 'distinct'.");
+    assert_eq!(3, distinct_titles.len());
+
+    let titles: Vec<_> = distinct_titles.iter().filter_map(|bson| match bson {
+        &Bson::String(ref title) => Some(title.to_owned()),
+        _ => None,
+    }).collect();
+
+    assert_eq!(3, titles.len());
+    assert!(titles.contains(&"Jaws".to_owned()));
+    assert!(titles.contains(&"Back to the Future".to_owned()));
+    assert!(titles.contains(&"12 Angry Men".to_owned()));
+
+    // Distinct titles over documents with certain director
+    let filter = doc! { "director" => Bson::String("MB".to_owned()) };
+    let distinct_titles = coll.distinct("title", Some(filter), None)
+        .ok().expect("Failed to execute 'distinct'.");
+
+    assert_eq!(2, distinct_titles.len());
+
+    let titles: Vec<_> = distinct_titles.iter().filter_map(|bson| match bson {
+        &Bson::String(ref title) => Some(title.to_owned()),
+        _ => None,
+    }).collect();
+
+    assert_eq!(2, titles.len());
+    assert!(titles.contains(&"Jaws".to_owned()));
+    assert!(titles.contains(&"12 Angry Men".to_owned()));
+}
 
 #[test]
 fn insert_many() {
@@ -383,7 +536,7 @@ fn update_many() {
     // Assert director attributes
     assert!(results[0].get("director").is_none());
     assert!(results[2].get("director").is_none());
-    
+
     match results[1].get("director") {
         Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
         _ => panic!("Expected Bson::String for director!"),


### PR DESCRIPTION
Implements `aggregate()`, `count()`, `distinct()`, and all of the FindAndModify commands on collections with preliminary testing (extensive spec test suite being built by @saghmrossi).