### PR TITLE
Change macros to be recursive

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,36 +1,34 @@
+use bson::{Bson, Document};
+
+#[macro_export]
+macro_rules! add_to_doc {
+    ($doc:expr, $key:expr => ($val:expr)) => {{
+        $doc.insert($key.to_owned(), $val);
+    }};
+
+    ($doc:expr, $key:expr => [$($val:expr),*]) => {{
+        let vec = vec![$($val),*];
+        $doc.insert($key.to_owned(), Bson::Array(vec));
+    }};
+
+    ($doc:expr, $key:expr => { $($k:expr => $v:tt),* }) => {{
+        $doc.insert($key.to_owned(), Bson::Document(doc! {
+            $(
+                $k => $v
+            ),*
+        }));
+    }};
+}
+
 #[macro_export]
 macro_rules! doc {
-    ( $( $k:expr => $v: expr),* ) => {
-        {
-            let mut doc = Document::new();
-            $(
-                doc.insert($k.to_owned(), $v);
-            )*
-            doc
-        }
-    };
-}
+    ( $($key:expr => $val:tt),* ) => {{
+        let mut document = Document::new();
 
-#[macro_export]
-macro_rules! nested_doc {
-    ( $( $k:expr => $v: expr),* ) => {
-        Bson::Document(doc!(
-            $( $k => $v),*
-        ))
-    }
-}
+        $(
+            add_to_doc!(document, $key => $val);
+        )*
 
-// Example for future documentation use
-//
-// ```
-// doc! {
-//     "_id" => Bson::I32(1),
-//     "x" => Bson::I32(11),
-//     "$filter" => nested_doc! {
-//         "_id" => nested_doc! {
-//             "$gt" => 1,
-//             "$lt" => 6
-//         }
-//     }
-// }
-// ```
+        document
+    }};
+}

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -1,6 +1,4 @@
-use bson;
-use bson::Bson;
-use bson::Document;
+use bson::{Bson, Document};
 
 use mongodb::client::MongoClient;
 
@@ -14,7 +12,7 @@ fn find_and_insert() {
 
     // Insert document
     let doc = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     coll.insert_one(doc, None).ok().expect("Failed to insert document");
@@ -42,7 +40,7 @@ fn find_and_insert_one() {
 
     // Insert document
     let doc = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     coll.insert_one(doc, None).ok().expect("Failed to insert document");
@@ -68,11 +66,11 @@ fn insert_many() {
 
     // Insert documents
     let doc1 = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     let doc2 = doc! {
-        "title" => Bson::String("Back to the Future".to_owned())
+        "title" => (Bson::String("Back to the Future".to_owned()))
     };
 
     coll.insert_many(vec![doc1, doc2], false, None).ok().expect("Failed to insert documents.");
@@ -103,11 +101,11 @@ fn delete_one() {
 
     // Insert documents
     let doc1 = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     let doc2 = doc! {
-        "title" => Bson::String("Back to the Future".to_owned())
+        "title" => (Bson::String("Back to the Future".to_owned()))
     };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone()], false, None)
@@ -136,11 +134,11 @@ fn delete_many() {
 
     // Insert documents
     let doc1 = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     let doc2 = doc! {
-        "title" => Bson::String("Back to the Future".to_owned())
+        "title" => (Bson::String("Back to the Future".to_owned()))
     };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc2.clone()], false, None)
@@ -169,15 +167,15 @@ fn replace_one() {
 
     // Insert documents
     let doc1 = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     let doc2 = doc! {
-        "title" => Bson::String("Back to the Future".to_owned())
+        "title" => (Bson::String("Back to the Future".to_owned()))
     };
 
     let doc3 = doc! {
-        "title" => Bson::String("12 Angry Men".to_owned())
+        "title" => (Bson::String("12 Angry Men".to_owned()))
     };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
@@ -213,17 +211,17 @@ fn update_one() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => Bson::String("Jaws".to_owned()) };
-    let doc2 = doc! { "title" => Bson::String("Back to the Future".to_owned()) };
-    let doc3 = doc! { "title" => Bson::String("12 Angry Men".to_owned()) };
+    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
+    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())) };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
 
     // Update single document
     let update = doc! {
-        "$set" => nested_doc! {
-            "director" => Bson::String("Robert Zemeckis".to_owned())
+        "$set" => {
+            "director" => (Bson::String("Robert Zemeckis".to_owned()))
         }
     };
 
@@ -252,15 +250,15 @@ fn update_many() {
 
     // Insert documents
     let doc1 = doc! {
-        "title" => Bson::String("Jaws".to_owned())
+        "title" => (Bson::String("Jaws".to_owned()))
     };
 
     let doc2 = doc! {
-        "title" => Bson::String("Back to the Future".to_owned())
+        "title" => (Bson::String("Back to the Future".to_owned()))
     };
 
     let doc3 = doc! {
-        "title" => Bson::String("12 Angry Men".to_owned())
+        "title" => (Bson::String("12 Angry Men".to_owned()))
     };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone(), doc2.clone()], false, None)
@@ -268,8 +266,8 @@ fn update_many() {
 
     // Update single document
     let update = doc! {
-        "$set" => nested_doc! {
-            "director" => Bson::String("Robert Zemeckis".to_owned())
+        "$set" => {
+            "director" => (Bson::String("Robert Zemeckis".to_owned()))
         }
     };
 
@@ -282,7 +280,7 @@ fn update_many() {
     // Assert director attributes
     assert!(results[0].get("director").is_none());
     assert!(results[2].get("director").is_none());
-    
+
     match results[1].get("director") {
         Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
         _ => panic!("Expected Bson::String for director!"),

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -1,5 +1,4 @@
-use bson::Document;
-use bson::Bson::I64;
+use bson::{Bson, Document};
 
 use mongodb::client::MongoClient;
 use mongodb::client::cursor::Cursor;
@@ -13,9 +12,9 @@ fn cursor_features() {
 
     db.drop_database().ok().expect("Failed to drop database.");
 
-    let docs : Vec<_> = (0..10).map(|i| {
+    let docs = (0..10).map(|i| {
         doc! {
-            "foo" => I64(i)
+            "foo" => (Bson::I64(i))
         }
     }).collect();
 
@@ -39,7 +38,7 @@ fn cursor_features() {
 
     for i in 0..batch.len() {
         match batch[i].get("foo") {
-            Some(&I64(j)) => assert_eq!(i as i64, j),
+            Some(&Bson::I64(j)) => assert_eq!(i as i64, j),
             _ => panic!("Wrong value returned from Cursor#next_batch")
         };
     }
@@ -50,7 +49,7 @@ fn cursor_features() {
     };
 
     match bson.get("foo") {
-        Some(&I64(3)) => (),
+        Some(&Bson::I64(3)) => (),
         _ => panic!("Wrong value returned from Cursor#next")
     };
 
@@ -62,7 +61,7 @@ fn cursor_features() {
 
     for i in 0..vec.len() {
         match vec[i].get("foo") {
-            Some(&I64(j)) => assert_eq!(4 + i as i64 , j),
+            Some(&Bson::I64(j)) => assert_eq!(4 + i as i64 , j),
             _ => panic!("Wrong value returned from Cursor#next_batch")
         };
     }

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -1,6 +1,4 @@
-use bson::Bson;
-use bson::Document;
-use bson::Bson::{FloatingPoint, I32};
+use bson::{Bson, Document};
 use mongodb::client::wire_protocol::flags::{OpInsertFlags, OpQueryFlags,
                                             OpUpdateFlags};
 use mongodb::client::wire_protocol::operations::Message;
@@ -12,7 +10,7 @@ fn insert_single_key_doc() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! {
-                "foo" => FloatingPoint(42.0)
+                "foo" => (Bson::FloatingPoint(42.0))
              };
 
             let docs = vec![doc];
@@ -60,7 +58,7 @@ fn insert_single_key_doc() {
             assert_eq!(docs.len() as i32, 1);
 
             match docs[0].get("foo") {
-                Some(&FloatingPoint(42.0)) => (),
+                Some(&Bson::FloatingPoint(42.0)) => (),
                 _ => panic!("Wrong value returned!")
             };
         },
@@ -75,8 +73,8 @@ fn insert_multi_key_doc() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! {
-                "foo" => FloatingPoint(42.0),
-                "bar" => Bson::String("__z&".to_owned())
+                "foo" => (Bson::FloatingPoint(42.0)),
+                "bar" => (Bson::String("__z&".to_owned()))
             };
 
             let docs = vec![doc];
@@ -124,7 +122,7 @@ fn insert_multi_key_doc() {
             assert_eq!(docs.len() as i32, 1);
 
             match docs[0].get("foo") {
-                Some(&FloatingPoint(42.0)) => (),
+                Some(&Bson::FloatingPoint(42.0)) => (),
                 _ => panic!("Wrong value returned!")
             };
 
@@ -144,12 +142,12 @@ fn insert_docs() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc1 = doc! {
-                "foo" => FloatingPoint(42.0),
-                "bar" => Bson::String("__z&".to_owned())
+                "foo" => (Bson::FloatingPoint(42.0)),
+                "bar" => (Bson::String("__z&".to_owned()))
             };
 
             let doc2 = doc! {
-                "booyah" => Bson::I32(23)
+                "booyah" => (Bson::I32(23))
             };
 
             let docs = vec![doc1, doc2];
@@ -198,7 +196,7 @@ fn insert_docs() {
             assert_eq!(docs.len() as i32, 2);
 
             match docs[0].get("foo") {
-                Some(&FloatingPoint(42.0)) => (),
+                Some(&Bson::FloatingPoint(42.0)) => (),
                 _ => panic!("Wrong value returned!")
             };
 
@@ -208,7 +206,7 @@ fn insert_docs() {
             };
 
             match docs[1].get("booyah") {
-                Some(&I32(23)) => (),
+                Some(&Bson::I32(23)) => (),
                 _ => panic!("Wrong value returned!")
             };
         },
@@ -224,7 +222,7 @@ fn insert_update_then_query() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! {
-                "foo" => FloatingPoint(42.0)
+                "foo" => (Bson::FloatingPoint(42.0))
             };
 
             let docs = vec![doc];
@@ -245,7 +243,7 @@ fn insert_update_then_query() {
             let selector = Document::new();
 
             let update = doc! {
-                "foo" => Bson::String("bar".to_owned())
+                "foo" => (Bson::String("bar".to_owned()))
             };
 
             let flags = OpUpdateFlags::no_flags();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,7 @@
 extern crate bson;
 
-#[macro_use(doc, nested_doc)]
+#[macro_use(add_to_doc, doc)]
 extern crate mongodb;
 
 mod client;
+mod macros;

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -1,0 +1,68 @@
+use bson::{Bson, Document};
+
+fn print_doc_with_indent_level(doc: &Document, n: i32) {
+    macro_rules! print_spaces {
+        ( $n:expr ) => {
+            for _ in 0..$n {
+                print!(" ");
+            }
+        };
+    }
+
+    println!("{{");
+
+    for (key, value) in doc.iter() {
+        print_spaces!(n + 4);
+        print!("{}: ", key);
+
+        print_bson_with_indent_level(value, n);
+        println!("");
+    }
+
+    print_spaces!(n);
+    println!("}}");
+}
+
+#[macro_export]
+macro_rules! print_doc {
+    ( $doc:expr ) => {
+        print_doc_with_indent_level($doc, 0)
+    };
+}
+
+fn print_bson_with_indent_level(bson: &Bson, n: i32) {
+    match bson {
+        &Bson::Document(ref d) => print_doc_with_indent_level(&d, n + 4),
+        &Bson::String(ref s) => print!("\"{}\",", s),
+        &Bson::Boolean(b) => print!("{},", b),
+        &Bson::Array(ref v) => {
+            print!("[ ");
+
+            for b in v {
+                print_bson_with_indent_level(b, n);
+                print!(" ");
+            }
+
+            print!("]");
+        },
+        ref bson => print!("{:?},", bson)
+    };
+}
+
+
+#[test]
+fn recursive_macro() {
+    let doc = doc! {
+        "a" => (Bson::String("foo".to_owned())),
+        "b" => {
+            "bar" => {
+                "harbor" => [Bson::String("seal".to_owned()), Bson::Boolean(false)],
+                "jelly" => (Bson::FloatingPoint(42.0))
+            },
+            "grape" => (Bson::I64(27))
+        },
+        "c" => [Bson::I32(-7)]
+    };
+
+    print_doc!(&doc);
+}


### PR DESCRIPTION
I figured out a way to make the `doc!` macro recursive (so we won't have to use `nested_doc!` for nested documents I also added in some syntactic sugar making BSON array literals as values in documents. The main trick to making this possible was having the macro parse the values as token trees rather than expressions, which has the slight downside of requiring values that aren't arrays or documents to be wrapped in parentheses, but I think this is definitely worth it to get rid of `nested_doc! { ... } ` and `Bson::Array(vec![...]))` in favor of `{ ... }` and `[ ... ]`.

I put a pretty comprehensive example in `tests/macros/mod.rs`, along with some helper functions (and a macro) to print out BSON documents in a more human-readable way. If you want to run the test in Cargo to see what the output looks like, you'll need to run it with `cargo test recursive_macro -- --nocapture` (the `-- --nocapture` allows the tests to print to standard output, which otherwise won't occur).

I'm submitting this as a pull request mostly just as a convenient way to show the code, but I'm wondering if this functionality should be put in a pull request to the BSON library that we're using. The helper functions used to print out the BSON documents could pretty easily be refactored into a ToString implementation, and it also makes some sense to bundle the macros with the actual definition of the BSON data structure rather than in this libary (although we'd want to make a point in our documentation that these exist to make sure that users of the driver are aware of them).