### PR TITLE
Removing some of the warnings

### DIFF
--- a/src/client/coll/mod.rs
+++ b/src/client/coll/mod.rs
@@ -12,7 +12,6 @@ use client::coll::results::*;
 use client::cursor::Cursor;
 
 use client::wire_protocol::flags::OpQueryFlags;
-use client::wire_protocol::operations::Message;
 
 /// Interfaces with a MongoDB collection.
 pub struct Collection<'a> {

--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -67,7 +67,7 @@ impl <'a> Cursor<'a> {
 
     fn get_bson_and_cid_from_command_message(message: Message) -> Option<(VecDeque<bson::Document>, i64, String)> {
         match Cursor::get_bson_and_cid_from_message(message) {
-            Some((v, cid)) => {
+            Some((v, _)) => {
                 if v.len() != 1 {
                     return None;
                 }
@@ -239,7 +239,7 @@ impl <'a> Cursor<'a> {
     /// Returns the first BSON document returned from the stream, or `None` if
     /// there are no more documents to read.
     fn next_from_stream(&mut self) -> Option<bson::Document> {
-        self.get_from_stream();
+        let _ = self.get_from_stream();
         self.buffer.pop_front()
     }
 
@@ -283,8 +283,9 @@ impl <'a> Cursor<'a> {
             false
         } else {
             if self.buffer.is_empty() && self.limit != 1 && self.cursor_id != 0 {
-                self.get_from_stream();
+                let _ = self.get_from_stream();
             }
+
             !self.buffer.is_empty()
         }
     }

--- a/src/client/db.rs
+++ b/src/client/db.rs
@@ -84,7 +84,7 @@ impl<'a> Database<'a> {
             spec.insert("filter".to_owned(), Bson::Document(filter.unwrap()));
         }
 
-        let mut cursor = try!(self.command_cursor(spec));
+        let cursor = try!(self.command_cursor(spec));
         Ok(cursor)
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
 use client::db::Database;
 use client::common::{ReadPreference, WriteConcern};
 use client::connstring::ConnectionString;
-use client::cursor::Cursor;
 
 /// Interfaces with a MongoDB server or replica set.
 pub struct MongoClient {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,3 @@
-use bson::{Bson, Document};
-
 #[macro_export]
 macro_rules! add_to_doc {
     ($doc:expr, $key:expr => ($val:expr)) => {{


### PR DESCRIPTION
Most of the warnings are caused by struct fields  and the parameters to the unimplemented methods in the API not being  used, but a few legitimate ones had fallen through the cracks. This pull request removes the ones that can be safely removed.