### PR TITLE
Use BSON Conversion Traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,16 +2,16 @@
 name = "mongodb"
 version = "0.1.0"
 dependencies = [
- "bson 0.1.0 (git+https://github.com/kyeah/bson-rs)",
+ "bson 0.1.2 (git+https://github.com/kyeah/bson-rs)",
  "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "nalgebra 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nalgebra 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bson"
-version = "0.1.0"
-source = "git+https://github.com/kyeah/bson-rs#af061a4a4f06cc522c6796b3e361b8938bd19142"
+version = "0.1.2"
+source = "git+https://github.com/kyeah/bson-rs#216b90600477dd6ccc8c6743fd3786f214a335f9"
 dependencies = [
  "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -44,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nalgebra"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ rustc-serialize = "0.3"
 
 [dependencies.bson]
 git = "https://github.com/kyeah/bson-rs"
-ref = "af061a4a4f06cc522c6796b3e361b8938bd19142"
+ref = "216b90600477dd6ccc8c6743fd3786f214a335f9"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,11 +1,11 @@
 #[macro_export]
 macro_rules! add_to_doc {
     ($doc:expr, $key:expr => ($val:expr)) => {{
-        $doc.insert($key.to_owned(), $val);
+        $doc.insert($key.to_owned(), ::std::convert::From::from($val));
     }};
 
     ($doc:expr, $key:expr => [$($val:expr),*]) => {{
-        let vec = vec![$($val),*];
+        let vec = vec![$(::std::convert::From::from($val)),*];
         $doc.insert($key.to_owned(), Bson::Array(vec));
     }};
 

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -12,7 +12,7 @@ fn find_and_insert() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert document
-    let doc = doc! { "title" => (Bson::String("Jaws".to_owned())) };
+    let doc = doc! { "title" => ("Jaws") };
     coll.insert_one(doc, None).ok().expect("Failed to insert document");
 
     // Find document
@@ -41,7 +41,7 @@ fn find_and_insert_one() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert document
-    let doc = doc! { "title" => (Bson::String("Jaws".to_owned())) };
+    let doc = doc! { "title" => ("Jaws") };
     coll.insert_one(doc, None).ok().expect("Failed to insert document");
 
     // Find single document
@@ -64,8 +64,8 @@ fn find_one_and_delete() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone()], false, None)
         .ok().expect("Failed to insert documents.");
@@ -104,9 +104,9 @@ fn find_one_and_replace() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
-    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
+    let doc3 = doc! { "title" => ("12 Angry Men") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
@@ -160,17 +160,15 @@ fn find_one_and_update() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
-    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
+    let doc3 = doc! { "title" => ("12 Angry Men") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
 
     // Update single document
-    let update = doc! {
-        "$set" => { "director" => (Bson::String("Robert Zemeckis".to_owned())) }
-    };
+    let update = doc! { "$set" => { "director" => ("Robert Zemeckis") } };
 
     let result = coll.find_one_and_update(doc2.clone(), update, None)
         .ok().expect("Failed to execute find_one_and_update command.");
@@ -203,29 +201,17 @@ fn aggregate() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let tags1 = vec![Bson::String("a".to_owned()),
-                     Bson::String("b".to_owned()),
-                     Bson::String("c".to_owned())];
-
-    let tags2 = vec![Bson::String("a".to_owned()),
-                     Bson::String("b".to_owned()),
-                     Bson::String("d".to_owned())];
-
-    let tags3 = vec![Bson::String("d".to_owned()),
-                     Bson::String("e".to_owned()),
-                     Bson::String("f".to_owned())];
-
-    let doc1 = doc! { "tags" => (Bson::Array(tags1)) };
-    let doc2 = doc! { "tags" => (Bson::Array(tags2)) };
-    let doc3 = doc! { "tags" => (Bson::Array(tags3)) };
+    let doc1 = doc! { "tags" => ["a", "b", "c"] };
+    let doc2 = doc! { "tags" => ["a", "b", "d"] };
+    let doc3 = doc! { "tags" => ["d", "e", "f"] };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
         .ok().expect("Failed to execute insert_many command.");
 
     // Build aggregation pipeline to unwind tag arrays and group distinct tags
-    let project = doc! { "$project" => { "tags" => (Bson::I32(1)) } };
-    let unwind = doc! { "$unwind" => (Bson::String("$tags".to_owned())) };
-    let group = doc! { "$group" => { "_id" => (Bson::String("$tags".to_owned())) } };
+    let project = doc! { "$project" => { "tags" => (1) } };
+    let unwind = doc! { "$unwind" => ("$tags") };
+    let group = doc! { "$group" => { "_id" => ("$tags") } };
 
     // Aggregate
     let mut cursor = coll.aggregate(vec![project, unwind, group], None)
@@ -261,8 +247,8 @@ fn count() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
 
     let mut vec = vec![doc1.clone()];
     for _ in 0..10 {
@@ -279,7 +265,7 @@ fn count() {
     let count_all = coll.count(None, None).ok().expect("Failed to execute count.");
     assert_eq!(11, count_all);
 
-    let no_doc = doc! { "title" => (Bson::String("Houdini".to_owned())) };
+    let no_doc = doc! { "title" => ("Houdini") };
     let count_none = coll.count(Some(no_doc), None).ok().expect("Failed to execute count.");
     assert_eq!(0, count_none);
 }
@@ -302,7 +288,7 @@ fn distinct_one() {
     let coll = db.collection("distinct_none");
 
     db.drop_database().ok().expect("Failed to drop database");
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc2 = doc! { "title" => ("Back to the Future") };
     coll.insert_one(doc2, None).ok().expect("Failed to insert document.");
 
     let distinct_titles = coll.distinct("title", None, None).ok().expect("Failed to execute 'distinct'.");
@@ -318,13 +304,13 @@ fn distinct() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())),
-                      "director" => (Bson::String("MB".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws"),
+                      "director" => ("MB") };
 
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc2 = doc! { "title" => ("Back to the Future") };
 
-    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())),
-                      "director" => (Bson::String("MB".to_owned())) };
+    let doc3 = doc! { "title" => ("12 Angry Men"),
+                      "director" => ("MB") };
 
     let mut vec = vec![doc1.clone()];
     for _ in 0..4 {
@@ -351,7 +337,7 @@ fn distinct() {
     assert!(titles.contains(&"12 Angry Men".to_owned()));
 
     // Distinct titles over documents with certain director
-    let filter = doc! { "director" => (Bson::String("MB".to_owned())) };
+    let filter = doc! { "director" => ("MB") };
     let distinct_titles = coll.distinct("title", Some(filter), None)
         .ok().expect("Failed to execute 'distinct'.");
 
@@ -376,8 +362,8 @@ fn insert_many() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
 
     coll.insert_many(vec![doc1, doc2], false, None).ok().expect("Failed to insert documents.");
 
@@ -406,8 +392,8 @@ fn delete_one() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone()], false, None)
         .ok().expect("Failed to insert documents.");
@@ -438,8 +424,8 @@ fn delete_many() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc2.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
@@ -470,9 +456,9 @@ fn replace_one() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
-    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
+    let doc3 = doc! { "title" => ("12 Angry Men") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
@@ -507,19 +493,15 @@ fn update_one() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
-    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
+    let doc3 = doc! { "title" => ("12 Angry Men") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
 
     // Update single document
-    let update = doc! {
-        "$set" => {
-            "director" => (Bson::String("Robert Zemeckis".to_owned()))
-        }
-    };
+    let update = doc! { "$set" => { "director" => ("Robert Zemeckis") } };
 
     coll.update_one(doc2.clone(), update, false, None).ok().expect("Failed to update document.");
 
@@ -545,19 +527,15 @@ fn update_many() {
     db.drop_database().ok().expect("Failed to drop database");
 
     // Insert documents
-    let doc1 = doc! { "title" => (Bson::String("Jaws".to_owned())) };
-    let doc2 = doc! { "title" => (Bson::String("Back to the Future".to_owned())) };
-    let doc3 = doc! { "title" => (Bson::String("12 Angry Men".to_owned())) };
+    let doc1 = doc! { "title" => ("Jaws") };
+    let doc2 = doc! { "title" => ("Back to the Future") };
+    let doc3 = doc! { "title" => ("12 Angry Men") };
 
     coll.insert_many(vec![doc1.clone(), doc2.clone(), doc3.clone(), doc2.clone()], false, None)
         .ok().expect("Failed to insert documents into collection.");
 
     // Update single document
-    let update = doc! {
-        "$set" => {
-            "director" => (Bson::String("Robert Zemeckis".to_owned()))
-        }
-    };
+    let update = doc! { "$set" => { "director" => ("Robert Zemeckis") } };
 
     coll.update_many(doc2.clone(), update, false, None).ok().expect("Failed to update documents.");
 

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -13,9 +13,7 @@ fn cursor_features() {
     db.drop_database().ok().expect("Failed to drop database.");
 
     let docs = (0..10).map(|i| {
-        doc! {
-            "foo" => (Bson::I64(i))
-        }
+        doc! { "foo" => (i as i64) }
     }).collect();
 
     assert!(coll.insert_many(docs, false, None).is_ok());

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -9,9 +9,7 @@ use std::net::TcpStream;
 fn insert_single_key_doc() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
-            let doc = doc! {
-                "foo" => (Bson::FloatingPoint(42.0))
-             };
+            let doc = doc! { "foo" => (42.0) };
 
             let docs = vec![doc];
             let flags = OpInsertFlags::no_flags();
@@ -73,8 +71,8 @@ fn insert_multi_key_doc() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! {
-                "foo" => (Bson::FloatingPoint(42.0)),
-                "bar" => (Bson::String("__z&".to_owned()))
+                "foo" => (42.0),
+                "bar" => ("__z&")
             };
 
             let docs = vec![doc];
@@ -142,12 +140,12 @@ fn insert_docs() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc1 = doc! {
-                "foo" => (Bson::FloatingPoint(42.0)),
-                "bar" => (Bson::String("__z&".to_owned()))
+                "foo" => (42.0),
+                "bar" => ("__z&")
             };
 
             let doc2 = doc! {
-                "booyah" => (Bson::I32(23))
+                "booyah" => (23)
             };
 
             let docs = vec![doc1, doc2];
@@ -221,9 +219,7 @@ fn insert_docs() {
 fn insert_update_then_query() {
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
-            let doc = doc! {
-                "foo" => (Bson::FloatingPoint(42.0))
-            };
+            let doc = doc! { "foo" => (42.0) };
 
             let docs = vec![doc];
             let flags = OpInsertFlags::no_flags();
@@ -242,9 +238,7 @@ fn insert_update_then_query() {
 
             let selector = Document::new();
 
-            let update = doc! {
-                "foo" => (Bson::String("bar".to_owned()))
-            };
+            let update = doc! { "foo" => ("bar") };
 
             let flags = OpUpdateFlags::no_flags();
             let name = "test.update".to_owned();

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -53,15 +53,15 @@ fn print_bson_with_indent_level(bson: &Bson, n: i32) {
 #[test]
 fn recursive_macro() {
     let doc = doc! {
-        "a" => (Bson::String("foo".to_owned())),
+        "a" => ("foo"),
         "b" => {
             "bar" => {
-                "harbor" => [Bson::String("seal".to_owned()), Bson::Boolean(false)],
-                "jelly" => (Bson::FloatingPoint(42.0))
+                "harbor" => ["seal", false],
+                "jelly" => (42.0)
             },
-            "grape" => (Bson::I64(27))
+            "grape" => (27)
         },
-        "c" => [Bson::I32(-7)]
+        "c" => [-7]
     };
 
     print_doc!(&doc);


### PR DESCRIPTION
I've updated the BSON library to provide `From<T>` conversion traits to Bson, allowing the `doc!` macro to automagically convert raw formats into most types of Bson (except for `JavaScriptCode(String)` and `Timestamp(i64)`, whose inner objects overlap with the common String and I64 types). This reduces boilerplate code considerably, allowing us to convert code like this:

```rust
let doc1 = doc! { "tags" => [Bson::String("a".to_owned()),
                             Bson::String("b".to_owned()),
                             Bson::String("c".to_owned())] };

let doc2 = doc! { "tags" => [Bson::String("a".to_owned()),
                             Bson::String("b".to_owned()),
                             Bson::String("d".to_owned())] };

let doc3 = doc! { "tags" => [Bson::String("d".to_owned()),
                             Bson::String("e".to_owned()),
                             Bson::String("f".to_owned())] };
```

into this:

```rust
let doc1 = doc! { "tags" => ["a"', "b", "c"] };
let doc2 = doc! { "tags" => ["a", "b", "d"] };
let doc3 = doc! { "tags" => ["d", "e", "f"] };
```