### PR TITLE
Connection pooling prototype + Client Sync

### DIFF
--- a/src/client/connstring.rs
+++ b/src/client/connstring.rs
@@ -8,7 +8,7 @@ pub const DEFAULT_PORT: u16 = 27017;
 pub const URI_SCHEME: &'static str = "mongodb://";
 
 /// Encapsulates the hostname and port of a host.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Host {
     pub host_name: String,
     pub ipc: String,
@@ -39,7 +39,7 @@ impl Host {
 }
 
 /// Encapsulates the options and read preference tags of a MongoDB connection.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionOptions {
     pub options: BTreeMap<String, String>,
     pub read_pref_tags: Vec<String>,
@@ -61,7 +61,7 @@ impl ConnectionOptions {
 }
 
 /// Encapsulates information for connection to a single MongoDB host or replicated set.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionString {
     pub hosts: Vec<Host>,
     pub string: Option<String>,

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -1,0 +1,130 @@
+use client::Result;
+use client::connstring::ConnectionString;
+use client::Error::OperationError;
+
+use std::net::TcpStream;
+use std::ops::Deref;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+
+pub static DEFAULT_POOL_SIZE: usize = 5;
+
+/// Handles threaded connections to a MongoDB server.
+#[derive(Clone)]
+pub struct ConnectionPool {
+    pub config: ConnectionString,
+    inner: Arc<Mutex<Pool>>,
+    locks: Vec<Arc<Mutex<bool>>>,
+    // First unpoisoned socket
+    first_socket: Arc<AtomicUsize>,
+}
+
+struct Pool {
+    /// The maximum number of concurrent connections allowed.
+    pub size: usize,
+    sockets: Vec<Arc<Mutex<TcpStream>>>,
+}
+
+/// Holds an available socket and its associated lock.
+pub struct PooledStream<'a> {
+    pub socket: Arc<Mutex<TcpStream>>,
+    guard: MutexGuard<'a, bool>,
+}
+
+impl ConnectionPool {
+
+    /// Returns a connection pool with a default size.
+    pub fn new(config: ConnectionString) -> ConnectionPool {
+        ConnectionPool::with_size(config, DEFAULT_POOL_SIZE)
+    }
+
+    /// Returns a connection pool with a specified capped size.
+    pub fn with_size(config: ConnectionString, size: usize) -> ConnectionPool {
+        let mut vec = Vec::with_capacity(size);
+        for _ in 0..size {
+            vec.push(Arc::new(Mutex::new(false)));
+        }
+        ConnectionPool {
+            config: config,
+            locks: vec,
+            first_socket: Arc::new(ATOMIC_USIZE_INIT),
+            inner: Arc::new(Mutex::new(Pool {
+                size: size,
+                sockets: Vec::with_capacity(size),
+            })),
+        }
+    }
+
+    /// Attempts to acquire a connected socket. If none are available and
+    /// the pool has not reached its maximum size, a new socket will connect.
+    /// Otherwise, the function will block until a socket is returned to the pool.
+    pub fn acquire_stream<'a>(&'a self) -> Result<PooledStream<'a>> {
+
+        {
+            // Lock pool to prevent modifications during selection.
+            let mut locked = try!(self.inner.lock());
+            if locked.size == 0 {
+                return Err(OperationError("Connection pool holds no sockets!".to_owned()));
+            }
+
+            let len = locked.sockets.len();
+
+            // Acquire available existing socket
+            for i in 0..len {
+                let lock = self.locks.get(i).unwrap();
+                if let Ok(guard) = lock.try_lock() {
+                    return Ok(PooledStream {
+                        socket: locked.sockets.get(i).unwrap().clone(),
+                        guard: guard,
+                    });
+                }
+            }
+
+            // Make a new connection
+            if len < locked.size {
+                let socket = try!(self.connect());
+                locked.sockets.push(Arc::new(Mutex::new((try!(self.connect())))));
+                let lock = self.locks.get(len + 1).unwrap();
+                let socket_guard = try!(lock.lock());
+                return Ok(PooledStream {
+                    socket: locked.sockets.get(len).unwrap().clone(),
+                    guard: socket_guard,
+                });
+            }
+        }
+
+        // Wait for the first unpoisoned socket, but without holding the connection pool.
+        let mut first = self.first_socket.deref().load(Ordering::SeqCst);
+        let mut socket_guard;
+        loop {
+            match self.locks.get(first) {
+                Some(lock) => match lock.lock() {
+                    Ok(guard) => {
+                        socket_guard = guard;
+                        break;
+                    },
+                    Err(_) => {
+                        first += 1;
+                    }
+                },
+                None => return Err(OperationError("All pool sockets are poisoned.".to_owned())),
+            }
+        }
+
+        self.first_socket.store(first, Ordering::SeqCst);
+        let mut locked = try!(self.inner.lock());
+
+        Ok(PooledStream {
+            socket: locked.sockets.get(0).unwrap().clone(),
+            guard: socket_guard,
+        })
+    }
+
+    // Connects to a MongoDB server as defined by the initial configuration.
+    fn connect(&self) -> Result<TcpStream> {
+        let host_name = self.config.hosts[0].host_name.to_owned();
+        let port = self.config.hosts[0].port;
+        let stream = try!(TcpStream::connect((&host_name[..], port)));
+        Ok(stream)
+    }
+}

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -1,5 +1,7 @@
 use bson;
 use mongodb::client::MongoClient;
+use std::sync::Arc;
+use std::thread;
 
 #[test]
 fn database_names() {
@@ -37,4 +39,48 @@ fn is_master() {
     let client = MongoClient::with_uri("mongodb://localhost:27017").unwrap();
     let res = client.is_master().ok().expect("Failed to execute is_master.");
     assert!(res);
+}
+
+#[test]
+fn is_sync() {
+    let client = Arc::new(MongoClient::with_uri("mongodb://localhost:27018").unwrap());    
+    let state_results = client.database_names().ok().expect("Failed to execute database_names.");
+    for name in state_results {
+        if name != "local" {
+            client.drop_database(&name[..]).ok().expect("Failed to drop database from server.");
+        }
+    }
+
+    let client1 = client.clone();
+    let client2 = client.clone();
+    
+    let base_results = client.database_names().ok().expect("Failed to execute database_names.");
+    assert_eq!(1, base_results.len());
+    assert_eq!("local", base_results[0]);
+
+    let child1 = thread::spawn(move || {
+        let db = client1.db("concurrent_db");
+        db.collection("test1").insert_one(bson::Document::new(), None)
+            .ok().expect("Failed to insert placeholder document into collection");
+        let results = client1.database_names().ok().expect("Failed to execute database_names.");
+        assert!(results.contains(&"concurrent_db".to_owned()));
+    });
+
+    let child2 = thread::spawn(move || {
+        let db = client2.db("concurrent_db_2");
+        db.collection("test2").insert_one(bson::Document::new(), None)
+            .ok().expect("Failed to insert placeholder document into collection");
+        let results = client2.database_names().ok().expect("Failed to execute database_names.");
+        assert!(results.contains(&"concurrent_db_2".to_owned()));
+    });
+
+    let _ = child1.join();
+    let _ = child2.join();
+    
+    // Check new dbs
+    let results = client.database_names().ok().expect("Failed to execute database_names.");
+    assert_eq!(3, results.len());
+    assert!(results.contains(&"local".to_owned()));
+    assert!(results.contains(&"concurrent_db".to_owned()));
+    assert!(results.contains(&"concurrent_db_2".to_owned()));
 }


### PR DESCRIPTION
After going through several iterations of different pooling implementations, this is the one that proved to be the most thread-safe without losing concurrency gains. The main socket lock is the dummy lock in `ConnectionPool.locks`, while the inner lock (which wraps the socket) is used only to dereference it mutably for reading and writing. It's necessary to keep the sockets in the mutable `inner` Pool for lazily connecting, and the socket locks in the immutable ConnectionPool for atomically locking and returning.

The one large remaining issue is poisoned socket locks, which will permanently kill a socket and limit the number of connections. Ideally, another connection should be opened, but the `ConnectionPool.locks` vec is immutable and cannot be locked with a mutex without restricting concurrency.

I initially tried a traditional pool with a `Mutex<TcpStream>` vector, but this makes it impossible to atomically lock and return the socket at once without also holding onto the overall Connection Pool lock or introducing a lock on the socket vec.

Another implementation [(pooling-v3)](https://github.com/kyeah/mongo-rust-driver-prototype/blob/pooling-v3/src/client/pool.rs) follows a pattern inspired by [hyper](https://github.com/hyperium/hyper/blob/master/src/client/pool.rs) where sockets are explicitly removed from and returned to the pool, but because Mongo pools are capped on the number of open connections, this forces it to use a `waiting_lock` so that it can wait for a connection to be returned, which can then lead to the entire pool being killed if any one thread dies and poisons the lock.