### PR TITLE
Initial work to support bulk writes

### DIFF
--- a/src/client/coll/batch.rs
+++ b/src/client/coll/batch.rs
@@ -2,6 +2,18 @@ use bson::Document;
 use client::coll::options::WriteModel;
 use client::coll::results::InsertManyResult;
 
+struct UpdateModel {
+    pub filter: Document,
+    pub update: Document,
+    pub upsert: bool,
+    pub multi: bool,
+}
+
+struct DeleteModel {
+    pub filter: Document,
+    pub multi: bool,
+}
+
 pub enum Batch {
     Insert {
         documents: Vec<Document>,

--- a/src/client/coll/batch.rs
+++ b/src/client/coll/batch.rs
@@ -1,0 +1,9 @@
+use bson::Document;
+use client::coll::options::WriteModel;
+use client::coll::results::InsertManyResult;
+
+pub enum Batch {
+    Insert {
+        documents: Vec<Document>,
+    }
+}

--- a/src/client/coll/options.rs
+++ b/src/client/coll/options.rs
@@ -20,26 +20,26 @@ pub enum ReturnDocument {
 /// Marker interface for writes that can be batched together.
 #[derive(Debug, Clone)]
 pub enum WriteModel {
-    InsertOneModel {
+    InsertOne {
         document: bson::Document,
     },
-    DeleteOneModel {
+    DeleteOne {
         filter: bson::Document,
     },
-    DeleteManyModel {
+    DeleteMany {
         filter: bson::Document,
     },
-    ReplaceOneModel {
+    ReplaceOne {
         filter: bson::Document,
         replacement: bson::Document,
         upsert: bool,
     },
-    UpdateOneModel {
+    UpdateOne {
         filter: bson::Document,
         update: bson::Document,
         upsert: bool,
     },
-    UpdateManyModel {
+    UpdateMany {
         filter: bson::Document,
         update: bson::Document,
         upsert: bool,

--- a/tests/client/bulk.rs
+++ b/tests/client/bulk.rs
@@ -23,15 +23,15 @@ fn bulk_ordered_insert_only() {
 
     for (i, result) in cursor.into_iter().enumerate() {
         let doc = result.unwrap();
-        let i = i + 1;
+        let expected_id = i + 1;
 
         match doc.get("_id") {
-            Some(&Bson::I32(j)) => assert_eq!(i as i32, j),
+            Some(&Bson::I32(j)) => assert_eq!(expected_id as i32, j),
             _ => panic!("Invalid id: {:?}", doc)
         }
 
         match doc.get("x") {
-            Some(&Bson::I32(j)) => assert_eq!(11 * i as i32, j),
+            Some(&Bson::I32(j)) => assert_eq!(11 * expected_id as i32, j),
             _ => panic!("Invalid id: {:?}", doc)
         }
     }
@@ -58,15 +58,15 @@ fn bulk_unordered_insert_only() {
 
     for (i, result) in cursor.into_iter().enumerate() {
         let doc = result.unwrap();
-        let i = i + 1;
+        let expected_id = i + 1;
 
         match doc.get("_id") {
-            Some(&Bson::I32(j)) => assert_eq!(i as i32, j),
+            Some(&Bson::I32(j)) => assert_eq!(expected_id as i32, j),
             _ => panic!("Invalid id: {:?}", doc)
         }
 
         match doc.get("x") {
-            Some(&Bson::I32(j)) => assert_eq!(11 * i as i32, j),
+            Some(&Bson::I32(j)) => assert_eq!(11 * expected_id as i32, j),
             _ => panic!("Invalid id: {:?}", doc)
         }
     }

--- a/tests/client/bulk.rs
+++ b/tests/client/bulk.rs
@@ -1,0 +1,73 @@
+use bson::{Bson, Document};
+use mongodb::client::coll::options::WriteModel;
+use mongodb::client::MongoClient;
+
+#[test]
+fn bulk_ordered_insert_only() {
+    let client = MongoClient::new("localhost", 27017).unwrap();
+    let db = client.db("test");
+    let coll = db.collection("bulk_ordered_insert_only");
+
+    coll.drop().unwrap();
+
+    let models = (1..5).map(|i| WriteModel::InsertOne { document: doc! {
+        "_id" => (i),
+        "x" => (i * 11)
+    }}).collect();
+
+    coll.bulk_write(models, true);
+
+    let cursor : Vec<_> = coll.find(None, None).unwrap().collect();
+
+    assert_eq!(cursor.len(), 4);
+
+    for (i, result) in cursor.into_iter().enumerate() {
+        let doc = result.unwrap();
+        let i = i + 1;
+
+        match doc.get("_id") {
+            Some(&Bson::I32(j)) => assert_eq!(i as i32, j),
+            _ => panic!("Invalid id: {:?}", doc)
+        }
+
+        match doc.get("x") {
+            Some(&Bson::I32(j)) => assert_eq!(11 * i as i32, j),
+            _ => panic!("Invalid id: {:?}", doc)
+        }
+    }
+}
+
+#[test]
+fn bulk_unordered_insert_only() {
+    let client = MongoClient::new("localhost", 27017).unwrap();
+    let db = client.db("test");
+    let coll = db.collection("bulk_unordered_insert_only");
+
+    coll.drop().unwrap();
+
+    let models = (1..5).map(|i| WriteModel::InsertOne { document: doc! {
+        "_id" => (i),
+        "x" => (i * 11)
+    }}).collect();
+
+    coll.bulk_write(models, false);
+
+    let cursor : Vec<_> = coll.find(None, None).unwrap().collect();
+
+    assert_eq!(cursor.len(), 4);
+
+    for (i, result) in cursor.into_iter().enumerate() {
+        let doc = result.unwrap();
+        let i = i + 1;
+
+        match doc.get("_id") {
+            Some(&Bson::I32(j)) => assert_eq!(i as i32, j),
+            _ => panic!("Invalid id: {:?}", doc)
+        }
+
+        match doc.get("x") {
+            Some(&Bson::I32(j)) => assert_eq!(11 * i as i32, j),
+            _ => panic!("Invalid id: {:?}", doc)
+        }
+    }
+}

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -1,3 +1,4 @@
+mod bulk;
 mod coll;
 mod connstring;
 mod crud_spec;


### PR DESCRIPTION
The initial implementations of the data structures pertaining to bulk writing were written well before the implementation of the actual functionality, so some minor changes and additions had to be made to make things easier. I also added the functionality for InsertOne models and tests for it.