### PR TITLE
Connection pooling using Condvar

### DIFF
--- a/src/client/cursor.rs
+++ b/src/client/cursor.rs
@@ -10,8 +10,6 @@ use client::wire_protocol::operations::Message;
 use std::collections::vec_deque::VecDeque;
 use std::io::{Read, Write};
 
-use std::ops::DerefMut;
-
 pub const DEFAULT_BATCH_SIZE: i32 = 20;
 
 /// Maintains a connection to the server and lazily returns documents from a
@@ -135,8 +133,7 @@ impl <'a> Cursor<'a> {
                                          query.clone(), return_field_selector);
 
         let stream = try!(client.acquire_stream());
-        let mut locked = try!(stream.socket.lock());
-        let mut socket = locked.deref_mut();
+        let mut socket = stream.get_socket();
 
         let message = try!(result);
         try!(message.write(&mut socket));
@@ -205,8 +202,7 @@ impl <'a> Cursor<'a> {
     /// Attempts to read another batch of BSON documents from the stream.
     fn get_from_stream(&mut self) -> Result<()> {
         let stream = try!(self.client.acquire_stream());
-        let mut locked = try!(stream.socket.lock());
-        let mut socket = locked.deref_mut();
+        let mut socket = stream.get_socket();
 
         let get_more = self.new_get_more_request();
         try!(get_more.write(&mut socket));

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -1,4 +1,4 @@
-use client::Error::OperationError;
+use client::Error::{ArgumentError, OperationError};
 use client::Result;
 use client::connstring::ConnectionString;
 
@@ -87,9 +87,13 @@ impl ConnectionPool {
 
     /// Sets the maximum number of open connections.
     pub fn set_size(&self, size: usize) -> Result<()> {
-        let mut locked = try!(self.inner.lock());
-        locked.size = size;
-        Ok(())
+        if size < 1 {
+            Err(ArgumentError("The connection pool size must be greater than zero.".to_owned()))
+        } else {
+            let mut locked = try!(self.inner.lock());
+            locked.size = size;
+            Ok(())
+        }
     }
     
     /// Attempts to acquire a connected socket. If none are available and

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -1,10 +1,9 @@
+use client::Error::OperationError;
 use client::Result;
 use client::connstring::ConnectionString;
-use client::Error::OperationError;
 
 use std::net::TcpStream;
-use std::ops::Deref;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Condvar, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 pub static DEFAULT_POOL_SIZE: usize = 5;
@@ -12,23 +11,58 @@ pub static DEFAULT_POOL_SIZE: usize = 5;
 /// Handles threaded connections to a MongoDB server.
 #[derive(Clone)]
 pub struct ConnectionPool {
+    /// The connection configuration.
     pub config: ConnectionString,
+    // The socket pool.
     inner: Arc<Mutex<Pool>>,
-    locks: Vec<Arc<Mutex<bool>>>,
-    // First unpoisoned socket
-    first_socket: Arc<AtomicUsize>,
+    // A condition variable used for threads waiting for the pool
+    // to be repopulated with available connections.
+    wait_lock: Arc<Condvar>,
 }
 
 struct Pool {
     /// The maximum number of concurrent connections allowed.
     pub size: usize,
-    sockets: Vec<Arc<Mutex<TcpStream>>>,
+    // The current number of open connections.
+    pub len: Arc<AtomicUsize>,
+    // The idle socket pool.
+    sockets: Vec<TcpStream>,
 }
 
-/// Holds an available socket and its associated lock.
-pub struct PooledStream<'a> {
-    pub socket: Arc<Mutex<TcpStream>>,
-    guard: MutexGuard<'a, bool>,
+/// Holds an available socket, with logic to return the socket
+/// to the connection pool when dropped.
+pub struct PooledStream {
+    // This socket will always be Some until it is
+    // returned to the pool using take().
+    socket: Option<TcpStream>,
+    pool: Arc<Mutex<Pool>>,
+    wait_lock: Arc<Condvar>,
+}
+
+impl PooledStream {
+    /// Returns a reference to the socket.
+    pub fn get_socket<'a>(&'a self) -> &'a TcpStream {
+        self.socket.as_ref().unwrap()
+    }
+}
+
+impl Drop for PooledStream {
+    fn drop(&mut self) {
+        // Attempt to lock and return the socket to the pool,
+        // or give up if the pool lock has been poisoned.
+        if let Ok(mut locked) = self.pool.lock() {
+            let len = locked.len.load(Ordering::SeqCst);
+            if len < locked.size {
+                locked.sockets.push(self.socket.take().unwrap());
+                if len == 0 {
+                    // Notify waiting threads that the pool has been repopulated.
+                    self.wait_lock.notify_one();
+                }
+            } else {
+                let _ = locked.len.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+    }
 }
 
 impl ConnectionPool {
@@ -40,84 +74,59 @@ impl ConnectionPool {
 
     /// Returns a connection pool with a specified capped size.
     pub fn with_size(config: ConnectionString, size: usize) -> ConnectionPool {
-        let mut vec = Vec::with_capacity(size);
-        for _ in 0..size {
-            vec.push(Arc::new(Mutex::new(false)));
-        }
         ConnectionPool {
             config: config,
-            locks: vec,
-            first_socket: Arc::new(ATOMIC_USIZE_INIT),
+            wait_lock: Arc::new(Condvar::new()),
             inner: Arc::new(Mutex::new(Pool {
+                len: Arc::new(ATOMIC_USIZE_INIT),
                 size: size,
                 sockets: Vec::with_capacity(size),
             })),
         }
     }
 
+    /// Sets the maximum number of open connections.
+    pub fn set_size(&self, size: usize) -> Result<()> {
+        let mut locked = try!(self.inner.lock());
+        locked.size = size;
+        Ok(())
+    }
+    
     /// Attempts to acquire a connected socket. If none are available and
     /// the pool has not reached its maximum size, a new socket will connect.
     /// Otherwise, the function will block until a socket is returned to the pool.
-    pub fn acquire_stream<'a>(&'a self) -> Result<PooledStream<'a>> {
+    pub fn acquire_stream(&self) -> Result<PooledStream> {
+        let mut locked = try!(self.inner.lock());
+        if locked.size == 0 {
+            return Err(OperationError("The connection pool does not allow connections; \
+                                       increase the size of the pool.".to_owned()));
+        }
 
-        {
-            // Lock pool to prevent modifications during selection.
-            let mut locked = try!(self.inner.lock());
-            if locked.size == 0 {
-                return Err(OperationError("Connection pool holds no sockets!".to_owned()));
-            }
-
-            let len = locked.sockets.len();
-
+        loop {
             // Acquire available existing socket
-            for i in 0..len {
-                let lock = self.locks.get(i).unwrap();
-                if let Ok(guard) = lock.try_lock() {
-                    return Ok(PooledStream {
-                        socket: locked.sockets.get(i).unwrap().clone(),
-                        guard: guard,
-                    });
-                }
-            }
-
-            // Make a new connection
-            if len < locked.size {
-                let socket = try!(self.connect());
-                locked.sockets.push(Arc::new(Mutex::new((try!(self.connect())))));
-                let lock = self.locks.get(len + 1).unwrap();
-                let socket_guard = try!(lock.lock());
+            if let Some(stream) = locked.sockets.pop() {
                 return Ok(PooledStream {
-                    socket: locked.sockets.get(len).unwrap().clone(),
-                    guard: socket_guard,
+                    socket: Some(stream),
+                    pool: self.inner.clone(),
+                    wait_lock: self.wait_lock.clone(),
                 });
             }
-        }
 
-        // Wait for the first unpoisoned socket, but without holding the connection pool.
-        let mut first = self.first_socket.deref().load(Ordering::SeqCst);
-        let mut socket_guard;
-        loop {
-            match self.locks.get(first) {
-                Some(lock) => match lock.lock() {
-                    Ok(guard) => {
-                        socket_guard = guard;
-                        break;
-                    },
-                    Err(_) => {
-                        first += 1;
-                    }
-                },
-                None => return Err(OperationError("All pool sockets are poisoned.".to_owned())),
+            // Attempt to make a new connection
+            let len = locked.len.load(Ordering::SeqCst);
+            if len < locked.size {
+                let socket = try!(self.connect());
+                let _ = locked.len.fetch_add(1, Ordering::SeqCst);
+                return Ok(PooledStream {
+                    socket: Some(socket),
+                    pool: self.inner.clone(),
+                    wait_lock: self.wait_lock.clone(),
+                });
             }
+
+            // Release lock and wait for pool to be repopulated
+            locked = try!(self.wait_lock.wait(locked));
         }
-
-        self.first_socket.store(first, Ordering::SeqCst);
-        let mut locked = try!(self.inner.lock());
-
-        Ok(PooledStream {
-            socket: locked.sockets.get(0).unwrap().clone(),
-            guard: socket_guard,
-        })
     }
 
     // Connects to a MongoDB server as defined by the initial configuration.


### PR DESCRIPTION
Connections are now explicitly taken and returned to the pool, similar to how pools are implemented in hyper. To allow pools to be capped on the number of open connections, a condition variable is introduced for locking the connection pool; if all available connections are in use, the thread will release the pool lock until it is notified that a connection has been returned.