### PR TITLE
Fixed the "borrowing issue"

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -34,7 +34,8 @@ impl Collection {
     /// Creates a collection representation with optional read and write controls.
     ///
     /// If `create` is specified, the collection will be explicitly created in the database.
-    pub fn new(db: Database, name: &str, _create: bool, read_preference: Option<ReadPreference>,
+    pub fn new(db: Database, name: &str, _create: bool,
+               read_preference: Option<ReadPreference>,
                write_concern: Option<WriteConcern>) -> Collection {
 
         let rp = read_preference.unwrap_or(db.read_preference.to_owned());
@@ -95,7 +96,8 @@ impl Collection {
     }
 
     /// Gets the number of documents matching the filter.
-    pub fn count(&self, filter: Option<bson::Document>, options: Option<CountOptions>) -> Result<i64> {
+    pub fn count(&self, filter: Option<bson::Document>,
+                 options: Option<CountOptions>) -> Result<i64> {
         let opts = options.unwrap_or(CountOptions::new());
 
         let mut spec = bson::Document::new();
@@ -122,8 +124,8 @@ impl Collection {
     }
 
     /// Finds the distinct values for a specified field across a single collection.
-    pub fn distinct(&self, field_name: &str, filter: Option<bson::Document>, options: Option<DistinctOptions>) -> Result<Vec<Bson>> {
-
+    pub fn distinct(&self, field_name: &str, filter: Option<bson::Document>,
+                    options: Option<DistinctOptions>) -> Result<Vec<Bson>> {
         let _opts = options.unwrap_or(DistinctOptions::new());
 
         let mut spec = bson::Document::new();
@@ -141,8 +143,8 @@ impl Collection {
     }
 
     /// Returns a list of documents within the collection that match the filter.
-    pub fn find(&self, filter: Option<bson::Document>, options: Option<FindOptions>)
-                -> Result<Cursor> {
+    pub fn find(&self, filter: Option<bson::Document>,
+                options: Option<FindOptions>) -> Result<Cursor> {
 
         let doc = filter.unwrap_or(bson::Document::new());
         let options = options.unwrap_or(FindOptions::new());
@@ -155,8 +157,8 @@ impl Collection {
     }
 
     /// Returns the first document within the collection that matches the filter, or None.
-    pub fn find_one(&self, filter: Option<bson::Document>, options: Option<FindOptions>)
-                    -> Result<Option<bson::Document>> {
+    pub fn find_one(&self, filter: Option<bson::Document>,
+                    options: Option<FindOptions>) -> Result<Option<bson::Document>> {
         let options = options.unwrap_or(FindOptions::new());
         let mut cursor = try!(self.find(filter, Some(options.with_limit(1))));
         match cursor.next() {
@@ -169,7 +171,8 @@ impl Collection {
     // Helper method for all findAndModify commands.
     fn find_and_modify(&self, cmd: &mut bson::Document,
                        filter: bson::Document, _max_time_ms: Option<i64>,
-                       projection: Option<bson::Document>, sort: Option<bson::Document>,
+                       projection: Option<bson::Document>,
+                       sort: Option<bson::Document>,
                        write_concern: Option<WriteConcern>)
                        -> Result<Option<bson::Document>> {
 
@@ -203,8 +206,9 @@ impl Collection {
     // Helper method for validated replace and update commands.
     fn find_one_and_replace_or_update(&self, filter: bson::Document, update: bson::Document,
                                       after: bool, max_time_ms: Option<i64>,
-                                      projection: Option<bson::Document>, sort: Option<bson::Document>,
-                                      upsert: bool, write_concern: Option<WriteConcern>) -> Result<Option<bson::Document>> {
+                                      projection: Option<bson::Document>,
+                                      sort: Option<bson::Document>, upsert: bool, write_concern:
+                                      Option<WriteConcern>) -> Result<Option<bson::Document>> {
 
         let mut cmd = bson::Document::new();
         cmd.insert("update".to_owned(), Bson::Document(update));
@@ -220,7 +224,7 @@ impl Collection {
 
     /// Finds a single document and deletes it, returning the original.
     pub fn find_one_and_delete(&self, filter: bson::Document,
-                               options: Option<FindOneAndDeleteOptions>)  -> Result<Option<bson::Document>> {
+                               options: Option<FindOneAndDeleteOptions>) -> Result<Option<bson::Document>> {
 
         let opts = options.unwrap_or(FindOneAndDeleteOptions::new());
         let mut cmd = bson::Document::new();
@@ -232,7 +236,7 @@ impl Collection {
     /// Finds a single document and replaces it, returning either the original
     /// or replaced document.
     pub fn find_one_and_replace(&self, filter: bson::Document, replacement: bson::Document,
-                                options: Option<FindOneAndUpdateOptions>)  -> Result<Option<bson::Document>> {
+                                options: Option<FindOneAndUpdateOptions>) -> Result<Option<bson::Document>> {
         let opts = options.unwrap_or(FindOneAndUpdateOptions::new());
         try!(Collection::validate_replace(&replacement));
         self.find_one_and_replace_or_update(filter, replacement, opts.return_document.to_bool(),
@@ -243,7 +247,7 @@ impl Collection {
     /// Finds a single document and updates it, returning either the original
     /// or updated document.
     pub fn find_one_and_update(&self, filter: bson::Document, update: bson::Document,
-                               options: Option<FindOneAndUpdateOptions>)  -> Result<Option<bson::Document>> {
+                               options: Option<FindOneAndUpdateOptions>) -> Result<Option<bson::Document>> {
         let opts = options.unwrap_or(FindOneAndUpdateOptions::new());
         try!(Collection::validate_update(&update));
         self.find_one_and_replace_or_update(filter, update, opts.return_document.to_bool(),
@@ -387,7 +391,8 @@ impl Collection {
     }
 
     /// Sends a batch of writes to the server at the same time.
-    pub fn bulk_write(&self, requests: Vec<WriteModel>, ordered: bool) -> BulkWriteResult {
+    pub fn bulk_write(&self, requests: Vec<WriteModel>,
+                      ordered: bool) -> BulkWriteResult {
         let batches = if ordered {
             Collection::get_ordered_batches(VecDeque::from_iter(requests.into_iter()))
         } else {
@@ -420,8 +425,7 @@ impl Collection {
 
     // Internal insertion helper function. Returns a vec of collected ids and a possible exception.
     fn insert(&self, docs: Vec<bson::Document>, ordered: bool,
-              write_concern: Option<WriteConcern>) -> Result<(Vec<Bson>,
-                                                              Option<BulkWriteException>)> {
+              write_concern: Option<WriteConcern>) -> Result<(Vec<Bson>, Option<BulkWriteException>)> {
 
         let wc =  write_concern.unwrap_or(self.write_concern.clone());
 
@@ -462,7 +466,8 @@ impl Collection {
 
     /// Inserts the provided document. If the document is missing an identifier,
     /// the driver should generate one.
-    pub fn insert_one(&self, doc: bson::Document, write_concern: Option<WriteConcern>) -> Result<InsertOneResult> {
+    pub fn insert_one(&self, doc: bson::Document,
+                      write_concern: Option<WriteConcern>) -> Result<InsertOneResult> {
         let (ids, bulk_exception) = try!(self.insert(vec!(doc), true, write_concern.clone()));
 
         if ids.len() == 0 {
@@ -508,7 +513,8 @@ impl Collection {
     }
 
     // Sends a batch of delete ops to the server at once.
-    fn bulk_delete(&self, models: Vec<DeleteModel>, ordered: bool, write_concern: Option<WriteConcern>) -> Result<BulkDeleteResult> {
+    fn bulk_delete(&self, models: Vec<DeleteModel>, ordered: bool,
+                   write_concern: Option<WriteConcern>) -> Result<BulkDeleteResult> {
 
         let wc = write_concern.unwrap_or(self.write_concern.clone());
 
@@ -543,7 +549,8 @@ impl Collection {
     }
 
     // Internal deletion helper function.
-    fn delete(&self, filter: bson::Document, multi: bool, write_concern: Option<WriteConcern>) -> Result<DeleteResult> {
+    fn delete(&self, filter: bson::Document, multi: bool,
+              write_concern: Option<WriteConcern>) -> Result<DeleteResult> {
 
         let result = try!(self.bulk_delete(vec!(DeleteModel::new(filter, multi)),
                                            true, write_concern));
@@ -552,17 +559,20 @@ impl Collection {
     }
 
     /// Deletes a single document.
-    pub fn delete_one(&self, filter: bson::Document, write_concern: Option<WriteConcern>) -> Result<DeleteResult> {
+    pub fn delete_one(&self, filter: bson::Document,
+                      write_concern: Option<WriteConcern>) -> Result<DeleteResult> {
         self.delete(filter, false, write_concern)
     }
 
     /// Deletes multiple documents.
-    pub fn delete_many(&self, filter: bson::Document, write_concern: Option<WriteConcern>) -> Result<DeleteResult> {
+    pub fn delete_many(&self, filter: bson::Document,
+                       write_concern: Option<WriteConcern>) -> Result<DeleteResult> {
         self.delete(filter, true, write_concern)
     }
 
     // Sends a batch of replace and update ops to the server at once.
-    fn bulk_update(&self, models: Vec<UpdateModel>, ordered: bool, write_concern: Option<WriteConcern>) -> Result<BulkUpdateResult> {
+    fn bulk_update(&self, models: Vec<UpdateModel>, ordered: bool,
+                   write_concern: Option<WriteConcern>) -> Result<BulkUpdateResult> {
         let wc = write_concern.unwrap_or(self.write_concern.clone());
 
         let mut updates = Vec::new();
@@ -599,7 +609,8 @@ impl Collection {
     }
 
     // Internal update helper function.
-    fn update(&self, filter: bson::Document, update: bson::Document, upsert: bool, multi: bool,
+    fn update(&self, filter: bson::Document, update: bson::Document,
+              upsert: bool, multi: bool,
               write_concern: Option<WriteConcern>) -> Result<UpdateResult> {
 
         let result = try!(self.bulk_update(vec!(UpdateModel::new(filter, update, upsert, multi)),
@@ -609,7 +620,8 @@ impl Collection {
     }
 
     /// Replaces a single document.
-    pub fn replace_one(&self, filter: bson::Document, replacement: bson::Document, upsert: bool,
+    pub fn replace_one(&self, filter: bson::Document,
+                       replacement: bson::Document, upsert: bool,
                        write_concern: Option<WriteConcern>) -> Result<UpdateResult> {
 
         let _ = try!(Collection::validate_replace(&replacement));

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -10,7 +10,7 @@ use self::error::{BulkWriteException, WriteException};
 use self::options::*;
 use self::results::*;
 
-use {ThreadedClient};
+use ThreadedClient;
 use common::{ReadPreference, WriteConcern};
 use cursor::Cursor;
 use db::{Database, ThreadedDatabase};

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -121,12 +121,12 @@ impl Cursor {
     ///
     /// Returns the cursor for the query results on success, or an Error on
     /// failure.
-    pub fn query_with_batch_size(client: Client,
-                                     namespace: String, batch_size: i32,
-                                     flags: OpQueryFlags, number_to_skip: i32,
-                                     number_to_return: i32, query: bson::Document,
-                                     return_field_selector: Option<bson::Document>,
-                                     is_cmd_cursor: bool) -> Result<Cursor> {
+    pub fn query_with_batch_size(client: Client, namespace: String,
+                                 batch_size: i32, flags: OpQueryFlags,
+                                 number_to_skip: i32, number_to_return: i32,
+                                 query: bson::Document,
+                                 return_field_selector: Option<bson::Document>,
+                                 is_cmd_cursor: bool) -> Result<Cursor> {
         let result = Message::new_query(client.get_req_id(), flags,
                                         namespace.to_owned(),
                                         number_to_skip, batch_size,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,5 +1,5 @@
 use bson::{self, Bson};
-use {Error, Client, Result};
+use {Error, Client, ThreadedClient, Result};
 use wire_protocol::flags::OpQueryFlags;
 use wire_protocol::operations::Message;
 use std::collections::vec_deque::VecDeque;
@@ -21,8 +21,8 @@ pub const DEFAULT_BATCH_SIZE: i32 = 20;
 /// `count` - How many documents have been returned so far.
 /// `buffer` - A cache for documents received from the query that have not
 ///            yet been returned.
-pub struct Cursor<'a> {
-    client: &'a Client,
+pub struct Cursor {
+    client: Client,
     namespace: String,
     batch_size: i32,
     cursor_id: i64,
@@ -31,7 +31,7 @@ pub struct Cursor<'a> {
     buffer: VecDeque<bson::Document>,
 }
 
-impl <'a> Cursor<'a> {
+impl Cursor {
     /// Construcs a new Cursor for a database command.
     ///
     /// # Arguments
@@ -43,9 +43,9 @@ impl <'a> Cursor<'a> {
     /// # Return value
     ///
     /// Returns the newly created Cursor on success, or an Error on failure.
-    pub fn command_cursor(client: &'a Client, db: &str,
-                          doc: bson::Document) -> Result<Cursor<'a>> {
-        Cursor::query_with_batch_size(client, format!("{}.$cmd", db),
+    pub fn command_cursor(client: Client, db: &str,
+                          doc: bson::Document) -> Result<Cursor> {
+        Cursor::query_with_batch_size(client.clone(), format!("{}.$cmd", db),
                                       1, OpQueryFlags::no_flags(), 0, 0,
                                       doc, None, true)
     }
@@ -121,12 +121,12 @@ impl <'a> Cursor<'a> {
     ///
     /// Returns the cursor for the query results on success, or an Error on
     /// failure.
-    pub fn query_with_batch_size<'b>(client: &'a Client,
+    pub fn query_with_batch_size(client: Client,
                                      namespace: String, batch_size: i32,
                                      flags: OpQueryFlags, number_to_skip: i32,
                                      number_to_return: i32, query: bson::Document,
                                      return_field_selector: Option<bson::Document>,
-                                     is_cmd_cursor: bool) -> Result<Cursor<'a>> {
+                                     is_cmd_cursor: bool) -> Result<Cursor> {
         let result = Message::new_query(client.get_req_id(), flags,
                                         namespace.to_owned(),
                                         number_to_skip, batch_size,
@@ -172,12 +172,12 @@ impl <'a> Cursor<'a> {
     ///
     /// Returns the cursor for the query results on success, or an error string
     /// on failure.
-    pub fn query(client: &'a Client, namespace: String,
+    pub fn query(client: Client, namespace: String,
                  flags: OpQueryFlags, number_to_skip: i32,
                  number_to_return: i32, query: bson::Document,
                  return_field_selector: Option<bson::Document>,
-                 is_cmd_cursor: bool) -> Result<Cursor<'a>> {
-        Cursor::query_with_batch_size(client, namespace, DEFAULT_BATCH_SIZE, flags,
+                 is_cmd_cursor: bool) -> Result<Cursor> {
+        Cursor::query_with_batch_size(client.clone(), namespace, DEFAULT_BATCH_SIZE, flags,
                                       number_to_skip,
                                       number_to_return, query,
                                       return_field_selector, is_cmd_cursor)
@@ -259,7 +259,7 @@ impl <'a> Cursor<'a> {
     }
 }
 
-impl <'a> Iterator for Cursor<'a> {
+impl Iterator for Cursor {
     type Item = Result<bson::Document>;
 
     /// Attempts to read a BSON document from the cursor.

--- a/src/db.rs
+++ b/src/db.rs
@@ -41,7 +41,7 @@ pub trait ThreadedDatabase {
 impl ThreadedDatabase for Database {
     /// Creates a database representation with optional read and write controls.
     fn open(client: Client, name: &str, read_preference: Option<ReadPreference>,
-               write_concern: Option<WriteConcern>) -> Database {
+            write_concern: Option<WriteConcern>) -> Database {
         let rp = read_preference.unwrap_or(client.read_preference.to_owned());
         let wc = write_concern.unwrap_or(client.write_concern.to_owned());
 
@@ -60,8 +60,8 @@ impl ThreadedDatabase for Database {
 
     /// Creates a collection representation with custom read and write controls.
     fn collection_with_prefs(&self, coll_name: &str, create: bool,
-                                 read_preference: Option<ReadPreference>,
-                                 write_concern: Option<WriteConcern>) -> Collection {
+                             read_preference: Option<ReadPreference>,
+                             write_concern: Option<WriteConcern>) -> Collection {
         Collection::new(self.clone(), coll_name, create, read_preference, write_concern)
     }
 
@@ -90,7 +90,7 @@ impl ThreadedDatabase for Database {
     }
 
     fn list_collections_with_batch_size(&self, filter: Option<bson::Document>,
-                                            batch_size: i32) -> Result<Cursor> {
+                                        batch_size: i32) -> Result<Cursor> {
 
         let mut spec = bson::Document::new();
         let mut cursor = bson::Document::new();

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,58 +1,82 @@
 use bson;
 use bson::Bson;
-use {Client, Result};
+use {Client, ThreadedClient, Result};
 use Error::OperationError;
 use coll::Collection;
 use coll::options::FindOptions;
 use common::{ReadPreference, WriteConcern};
 use cursor::{Cursor, DEFAULT_BATCH_SIZE};
+use std::sync::Arc;
 
 /// Interfaces with a MongoDB database.
-pub struct Database<'a> {
+pub struct DatabaseInner {
     pub name: String,
-    pub client: &'a Client,
+    pub client: Client,
     pub read_preference: ReadPreference,
     pub write_concern: WriteConcern,
 }
 
-impl<'a> Database<'a> {
+pub type Database = Arc<DatabaseInner>;
+
+pub trait ThreadedDatabase {
     /// Creates a database representation with optional read and write controls.
-    pub fn new(client: &'a Client, name: &str,
-               read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Database<'a> {
+    fn open(client: Client, name: &str, read_preference: Option<ReadPreference>,
+           write_concern: Option<WriteConcern>) -> Database;
+    fn collection(&self, coll_name: &str) -> Collection;
+    fn collection_with_prefs(&self, coll_name: &str, create: bool,
+                             read_preference: Option<ReadPreference>,
+                             write_concern: Option<WriteConcern>) -> Collection;
+    fn get_req_id(&self) -> i32;
+    fn command_cursor(&self, spec: bson::Document) -> Result<Cursor>;
+    fn command(&self, spec: bson::Document) -> Result<bson::Document>;
+    fn list_collections(&self, filter: Option<bson::Document>) -> Result<Cursor>;
+    fn list_collections_with_batch_size(&self, filter: Option<bson::Document>,
+                                        batch_size: i32) -> Result<Cursor>;
+    fn collection_names(&self, filter: Option<bson::Document>) -> Result<Vec<String>>;
+    fn create_collection(&self, name: &str) -> Result<()>;
+    fn drop_database(&self) -> Result<()>;
+    fn drop_collection(&self, name: &str) -> Result<()>;
+}
+
+impl ThreadedDatabase for Database {
+    /// Creates a database representation with optional read and write controls.
+    fn open(client: Client, name: &str, read_preference: Option<ReadPreference>,
+               write_concern: Option<WriteConcern>) -> Database {
         let rp = read_preference.unwrap_or(client.read_preference.to_owned());
         let wc = write_concern.unwrap_or(client.write_concern.to_owned());
 
-        Database {
+        Arc::new(DatabaseInner {
             name: name.to_owned(),
             client: client,
             read_preference: rp,
             write_concern: wc,
-        }
+        })
     }
 
     /// Creates a collection representation with inherited read and write controls.
-    pub fn collection(&'a self, coll_name: &str) -> Collection<'a> {
-        Collection::new(self, coll_name, false, Some(self.read_preference.to_owned()), Some(self.write_concern.to_owned()))
+    fn collection(&self, coll_name: &str) -> Collection {
+        Collection::new(self.clone(), coll_name, false, Some(self.read_preference.to_owned()), Some(self.write_concern.to_owned()))
     }
 
     /// Creates a collection representation with custom read and write controls.
-    pub fn collection_with_prefs(&'a self, coll_name: &str, create: bool,
-                                 read_preference: Option<ReadPreference>, write_concern: Option<WriteConcern>) -> Collection<'a> {
-        Collection::new(self, coll_name, create, read_preference, write_concern)
+    fn collection_with_prefs(&self, coll_name: &str, create: bool,
+                                 read_preference: Option<ReadPreference>,
+                                 write_concern: Option<WriteConcern>) -> Collection {
+        Collection::new(self.clone(), coll_name, create, read_preference, write_concern)
     }
 
     /// Return a unique operational request id.
-    pub fn get_req_id(&self) -> i32 {
+    fn get_req_id(&self) -> i32 {
         self.client.get_req_id()
     }
 
     /// Generates a cursor for a relevant operational command.
-    pub fn command_cursor(&self, spec: bson::Document) -> Result<Cursor> {
-        Cursor::command_cursor(self.client, &self.name[..], spec)
+    fn command_cursor(&self, spec: bson::Document) -> Result<Cursor> {
+        Cursor::command_cursor(self.client.clone(), &self.name[..], spec)
     }
 
     /// Sends an administrative command over find_one.
-    pub fn command(&'a self, spec: bson::Document) -> Result<bson::Document> {
+    fn command(&self, spec: bson::Document) -> Result<bson::Document> {
         let coll = self.collection("$cmd");
         let mut options = FindOptions::new();
         options.batch_size = 1;
@@ -61,11 +85,11 @@ impl<'a> Database<'a> {
     }
 
     /// Returns a list of collections within the database.
-    pub fn list_collections(&'a self, filter: Option<bson::Document>) -> Result<Cursor> {
+    fn list_collections(&self, filter: Option<bson::Document>) -> Result<Cursor> {
         self.list_collections_with_batch_size(filter, DEFAULT_BATCH_SIZE)
     }
 
-    pub fn list_collections_with_batch_size(&'a self, filter: Option<bson::Document>,
+    fn list_collections_with_batch_size(&self, filter: Option<bson::Document>,
                                             batch_size: i32) -> Result<Cursor> {
 
         let mut spec = bson::Document::new();
@@ -83,7 +107,7 @@ impl<'a> Database<'a> {
 
 
     /// Returns a list of collection names within the database.
-    pub fn collection_names(&'a self, filter: Option<bson::Document>) -> Result<Vec<String>> {
+    fn collection_names(&self, filter: Option<bson::Document>) -> Result<Vec<String>> {
         let mut cursor = try!(self.list_collections(filter));
         let mut results = vec![];
         loop {
@@ -101,12 +125,12 @@ impl<'a> Database<'a> {
     ///
     /// Note that due to the implicit creation of collections during insertion, this
     /// method should only be used to instantiate capped collections.
-    pub fn create_collection(&'a self, name: &str) -> Result<()> {
+    fn create_collection(&self, name: &str) -> Result<()> {
         unimplemented!()
     }
 
     /// Permanently deletes the database from the server.
-    pub fn drop_database(&'a self) -> Result<()> {
+    fn drop_database(&self) -> Result<()> {
         let mut spec = bson::Document::new();
         spec.insert("dropDatabase".to_owned(), Bson::I32(1));
         try!(self.command(spec));
@@ -114,7 +138,7 @@ impl<'a> Database<'a> {
     }
 
     /// Permanently deletes the collection from the database.
-    pub fn drop_collection(&'a self, name: &str) -> Result<()> {
+    fn drop_collection(&self, name: &str) -> Result<()> {
         let mut spec = bson::Document::new();
         spec.insert("drop".to_owned(), Bson::String(name.to_owned()));
         try!(self.command(spec));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ impl ThreadedClient for Client {
     }
 
     fn with_config(config: ConnectionString, read_pref: Option<ReadPreference>,
-        write_concern: Option<WriteConcern>) -> Result<Client> {
+                   write_concern: Option<WriteConcern>) -> Result<Client> {
 
         let rp = match read_pref {
             Some(rp) => rp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl ThreadedClient for Client {
 
     /// `new` with custom read and write controls.
     fn with_prefs(host: &str, port: u16, read_pref: Option<ReadPreference>,
-                      write_concern: Option<WriteConcern>) -> Result<Client> {
+                  write_concern: Option<WriteConcern>) -> Result<Client> {
         let config = ConnectionString::new(host, port);
         Client::with_config(config, read_pref, write_concern)
     }
@@ -80,7 +80,7 @@ impl ThreadedClient for Client {
 
     /// `with_uri` with custom read and write controls.
     fn with_uri_and_prefs(uri: &str, read_pref: Option<ReadPreference>,
-                              write_concern: Option<WriteConcern>) -> Result<Client> {
+                          write_concern: Option<WriteConcern>) -> Result<Client> {
         let config = try!(connstring::parse(uri));
         Client::with_config(config, read_pref, write_concern)
     }
@@ -113,7 +113,7 @@ impl ThreadedClient for Client {
 
     /// Creates a database representation with custom read and write controls.
     fn db_with_prefs(&self, db_name: &str, read_preference: Option<ReadPreference>,
-                             write_concern: Option<WriteConcern>) -> Database {
+                     write_concern: Option<WriteConcern>) -> Database {
         Database::open(self.clone(), db_name, read_preference, write_concern)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,29 +24,48 @@ use std::sync::atomic::{AtomicIsize, Ordering, ATOMIC_ISIZE_INIT};
 
 use common::{ReadPreference, WriteConcern};
 use connstring::ConnectionString;
-use db::Database;
+use db::{Database, ThreadedDatabase};
 use error::Error::ResponseError;
 use pool::{ConnectionPool, PooledStream};
 
 /// Interfaces with a MongoDB server or replica set.
 #[derive(Clone)]
-pub struct Client {
+pub struct ClientInner {
     req_id: Arc<AtomicIsize>,
     pool: ConnectionPool,
     pub read_preference: ReadPreference,
     pub write_concern: WriteConcern,
 }
 
-unsafe impl Sync for Client {}
+pub trait ThreadedClient: Sync {
+    fn connect(host: &str, port: u16) -> Result<Self>;
+    fn with_prefs(host: &str, port: u16, read_pref: Option<ReadPreference>,
+                      write_concern: Option<WriteConcern>) -> Result<Self>;
+    fn with_uri(uri: &str) -> Result<Self>;
+    fn with_uri_and_prefs(uri: &str, read_pref: Option<ReadPreference>,
+                              write_concern: Option<WriteConcern>) -> Result<Self>;
+    fn with_config(config: ConnectionString, read_pref: Option<ReadPreference>,
+                   write_concern: Option<WriteConcern>) -> Result<Self>;
+    fn db<'a>(&'a self, db_name: &str) -> Database;
+    fn db_with_prefs(&self, db_name: &str, read_preference: Option<ReadPreference>,
+                         write_concern: Option<WriteConcern>) -> Database;
+    fn acquire_stream(&self) -> Result<PooledStream>;
+    fn get_req_id(&self) -> i32;
+    fn database_names(&self) -> Result<Vec<String>>;
+    fn drop_database(&self, db_name: &str) -> Result<()>;
+    fn is_master(&self) -> Result<bool>;
+}
 
-impl Client {
+pub type Client = Arc<ClientInner>;
+
+impl ThreadedClient for Client {
     /// Creates a new Client connected to a single MongoDB server.
-    pub fn new(host: &str, port: u16) -> Result<Client> {
+    fn connect(host: &str, port: u16) -> Result<Client> {
         Client::with_prefs(host, port, None, None)
     }
 
     /// `new` with custom read and write controls.
-    pub fn with_prefs(host: &str, port: u16, read_pref: Option<ReadPreference>,
+    fn with_prefs(host: &str, port: u16, read_pref: Option<ReadPreference>,
                       write_concern: Option<WriteConcern>) -> Result<Client> {
         let config = ConnectionString::new(host, port);
         Client::with_config(config, read_pref, write_concern)
@@ -55,19 +74,19 @@ impl Client {
     /// Creates a new Client connected to a server or replica set using
     /// a MongoDB connection string URI as defined by
     /// [the manual](http://docs.mongodb.org/manual/reference/connection-string/).
-    pub fn with_uri(uri: &str) -> Result<Client> {
+    fn with_uri(uri: &str) -> Result<Client> {
         Client::with_uri_and_prefs(uri, None, None)
     }
 
     /// `with_uri` with custom read and write controls.
-    pub fn with_uri_and_prefs(uri: &str, read_pref: Option<ReadPreference>,
+    fn with_uri_and_prefs(uri: &str, read_pref: Option<ReadPreference>,
                               write_concern: Option<WriteConcern>) -> Result<Client> {
         let config = try!(connstring::parse(uri));
         Client::with_config(config, read_pref, write_concern)
     }
 
     fn with_config(config: ConnectionString, read_pref: Option<ReadPreference>,
-                   write_concern: Option<WriteConcern>) -> Result<Client> {
+        write_concern: Option<WriteConcern>) -> Result<Client> {
 
         let rp = match read_pref {
             Some(rp) => rp,
@@ -79,37 +98,37 @@ impl Client {
             None => WriteConcern::new(),
         };
 
-        Ok(Client {
+        Ok(Arc::new(ClientInner {
             req_id: Arc::new(ATOMIC_ISIZE_INIT),
             pool: ConnectionPool::new(config),
             read_preference: rp,
             write_concern: wc,
-        })
+        }))
     }
 
     /// Creates a database representation with default read and write controls.
-    pub fn db<'a>(&'a self, db_name: &str) -> Database<'a> {
-        Database::new(self, db_name, None, None)
+    fn db(&self, db_name: &str) -> Database {
+        Database::open(self.clone(), db_name, None, None)
     }
 
     /// Creates a database representation with custom read and write controls.
-    pub fn db_with_prefs<'a>(&'a self, db_name: &str, read_preference: Option<ReadPreference>,
-                             write_concern: Option<WriteConcern>) -> Database<'a> {
-        Database::new(self, db_name, read_preference, write_concern)
+    fn db_with_prefs(&self, db_name: &str, read_preference: Option<ReadPreference>,
+                             write_concern: Option<WriteConcern>) -> Database {
+        Database::open(self.clone(), db_name, read_preference, write_concern)
     }
 
     /// Acquires a connection stream from the pool.
-    pub fn acquire_stream(&self) -> Result<PooledStream> {
+    fn acquire_stream(&self) -> Result<PooledStream> {
         Ok(try!(self.pool.acquire_stream()))
     }
 
     /// Returns a unique operational request id.
-    pub fn get_req_id(&self) -> i32 {
+    fn get_req_id(&self) -> i32 {
         self.req_id.fetch_add(1, Ordering::SeqCst) as i32
     }
 
     /// Returns a list of all database names that exist on the server.
-    pub fn database_names(&self) -> Result<Vec<String>> {
+    fn database_names(&self) -> Result<Vec<String>> {
         let mut doc = bson::Document::new();
         doc.insert("listDatabases".to_owned(), Bson::I32(1));
 
@@ -132,14 +151,14 @@ impl Client {
     }
 
     /// Drops the database defined by `db_name`.
-    pub fn drop_database(&self, db_name: &str) -> Result<()> {
+    fn drop_database(&self, db_name: &str) -> Result<()> {
         let db = self.db(db_name);
         try!(db.drop_database());
         Ok(())
     }
 
     /// Reports whether this instance is a primary, master, mongos, or standalone mongod instance.
-    pub fn is_master(&self) -> Result<bool> {
+    fn is_master(&self) -> Result<bool> {
         let mut doc = bson::Document::new();
         doc.insert("isMaster".to_owned(), Bson::I32(1));
 

--- a/tests/client/bulk.rs
+++ b/tests/client/bulk.rs
@@ -1,10 +1,11 @@
 use bson::Bson;
 use mongodb::coll::options::WriteModel;
-use mongodb::Client;
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
 
 #[test]
 fn bulk_ordered_insert_only() {
-    let client = Client::new("localhost", 27017).unwrap();
+    let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test");
     let coll = db.collection("bulk_ordered_insert_only");
 
@@ -39,7 +40,7 @@ fn bulk_ordered_insert_only() {
 
 #[test]
 fn bulk_unordered_insert_only() {
-    let client = Client::new("localhost", 27017).unwrap();
+    let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test");
     let coll = db.collection("bulk_unordered_insert_only");
 
@@ -134,7 +135,7 @@ fn bulk_ordered_mix() {
         }},
     ];
 
-    let client = Client::new("localhost", 27017).unwrap();
+    let client = Client::connect("localhost", 27017).unwrap();
     let db = client.db("test");
     let coll = db.collection("bulk_ordered_mix");
 

--- a/tests/client/client.rs
+++ b/tests/client/client.rs
@@ -1,5 +1,6 @@
 use bson;
-use mongodb::Client;
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
 use std::sync::Arc;
 use std::thread;
 
@@ -43,7 +44,7 @@ fn is_master() {
 
 #[test]
 fn is_sync() {
-    let client = Arc::new(Client::with_uri("mongodb://localhost:27018").unwrap());    
+    let client = Arc::new(Client::with_uri("mongodb://localhost:27018").unwrap());
     let state_results = client.database_names().ok().expect("Failed to execute database_names.");
     for name in state_results {
         if name != "local" {
@@ -53,7 +54,7 @@ fn is_sync() {
 
     let client1 = client.clone();
     let client2 = client.clone();
-    
+
     let base_results = client.database_names().ok().expect("Failed to execute database_names.");
     assert_eq!(1, base_results.len());
     assert_eq!("local", base_results[0]);
@@ -76,7 +77,7 @@ fn is_sync() {
 
     let _ = child1.join();
     let _ = child2.join();
-    
+
     // Check new dbs
     let results = client.database_names().ok().expect("Failed to execute database_names.");
     assert_eq!(3, results.len());

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -1,6 +1,7 @@
 use bson::Bson;
 
-use mongodb::Client;
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
 use mongodb::coll::options::{FindOneAndUpdateOptions, ReturnDocument};
 
 #[test]

--- a/tests/client/crud_spec/framework.rs
+++ b/tests/client/crud_spec/framework.rs
@@ -244,7 +244,7 @@ macro_rules! run_suite {
     ( $file:expr, $coll:expr ) => {{
         let json = Json::from_file($file).unwrap();
         let mut suite = json.get_suite().unwrap();
-        let client =  Client::new("localhost", 27017).unwrap();
+        let client =  Client::connect("localhost", 27017).unwrap();
         let db = client.db("test");
         let coll = db.collection($coll);
 

--- a/tests/client/crud_spec/read.rs
+++ b/tests/client/crud_spec/read.rs
@@ -2,7 +2,8 @@ use bson::Bson;
 use json::arguments::Arguments;
 use json::reader::SuiteContainer;
 use json::eq::{self, NumEq};
-use mongodb:: Client;
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
 use rustc_serialize::json::Json;
 
 #[test]

--- a/tests/client/crud_spec/write.rs
+++ b/tests/client/crud_spec/write.rs
@@ -2,7 +2,8 @@ use bson::Bson;
 use json::arguments::Arguments;
 use json::reader::SuiteContainer;
 use json::eq::{self, NumEq};
-use mongodb:: Client;
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
 use rustc_serialize::json::Json;
 
 #[test]

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -1,5 +1,6 @@
 use bson::{Bson, Document};
-use mongodb::Client;
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
 use mongodb::cursor::Cursor;
 use mongodb::wire_protocol::flags::OpQueryFlags;
 
@@ -20,7 +21,7 @@ fn cursor_features() {
     let doc = Document::new();
     let flags = OpQueryFlags::no_flags();
 
-    let result = Cursor::query_with_batch_size(&client, "test.cursor_test".to_owned(),
+    let result = Cursor::query_with_batch_size(client.clone(), "test.cursor_test".to_owned(),
                                                3, flags,
                                                0, 0, doc, None, false);
 


### PR DESCRIPTION
Instead of `Database` having a reference to `Client` and `Collection` having a reference to `Database`, they now both use `Arc`'s, which allows them to be used in multiple threads.