### PR TITLE
Index operations & refactor tests to drop collections

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1,6 +1,9 @@
-use bson;
+use bson::{self, Bson};
 use cursor;
 use common::{ReadPreference, WriteConcern};
+
+use Error::ArgumentError;
+use Result;
 
 /// Describes the type of cursor to return on collection queries.
 #[derive(Clone, PartialEq, Eq)]
@@ -112,6 +115,36 @@ pub struct FindOneAndUpdateOptions {
     pub write_concern: Option<WriteConcern>,
 }
 
+/// Options for index operations.
+pub struct IndexOptions {
+    pub background: Option<bool>,
+    pub expire_after_seconds: Option<i32>,
+    pub name: Option<String>,
+    pub sparse: Option<bool>,
+    pub storage_engine: Option<String>,
+    pub unique: Option<bool>,
+    pub version: Option<i32>,
+    // Options for text indexes
+    pub default_language: Option<String>,
+    pub language_override: Option<String>,
+    pub text_version: Option<i32>,
+    pub weights: Option<bson::Document>,
+    // Options for 2dsphere indexes
+    pub sphere_version: Option<i32>,
+    // Options for 2d indexes
+    pub bits: Option<i32>,
+    pub max: Option<f64>,
+    pub min: Option<f64>,
+    // Options for geoHaystack indexes
+    pub bucket_size: Option<i32>,
+}
+
+/// A single index model.
+pub struct IndexModel {
+    pub keys: bson::Document,
+    pub options: IndexOptions,
+}
+
 impl AggregateOptions {
     pub fn new() -> AggregateOptions {
         AggregateOptions {
@@ -195,6 +228,125 @@ impl FindOneAndUpdateOptions {
             upsert: false,
             write_concern: None,
         }
+    }
+}
+
+impl IndexOptions {
+    pub fn new() -> IndexOptions {
+        IndexOptions {
+            background: None,
+            expire_after_seconds: None,
+            name: None,
+            sparse: None,
+            storage_engine: None,
+            unique: None,
+            version: None,
+            default_language: None,
+            language_override: None,
+            text_version: None,
+            weights: None,
+            sphere_version: None,
+            bits: None,
+            max: None,
+            min: None,
+            bucket_size: None,
+        }
+    }
+}
+
+impl IndexModel {
+    pub fn new(keys: bson::Document, options: Option<IndexOptions>) -> IndexModel {
+        IndexModel {
+            keys: keys,
+            options: options.unwrap_or(IndexOptions::new()),
+        }
+    }
+
+    /// Returns the name of the index as specified by the options, or
+    /// as automatically generated using the keys.
+    pub fn name(&self) -> Result<String> {
+        Ok(match self.options.name {
+            Some(ref name) => name.to_owned(),
+            None => try!(self.generate_index_name()),
+        })
+    }
+    
+    /// Generates the index name from keys.
+    /// Auto-generated names have the form "key1_val1_key2_val2..."
+    pub fn generate_index_name(&self) -> Result<String> {
+        let mut name = String::new();
+        for (key, bson) in self.keys.iter() {
+            if !name.is_empty() {
+                name.push_str("_");
+            }
+
+            name.push_str(&key);
+            name.push_str("_");
+            match bson {
+                &Bson::I32(ref i) => name.push_str(&format!("{}", i)),
+                _ => return Err(ArgumentError("Index model keys must map to i32.".to_owned())),
+            }
+        }
+        Ok(name)
+    }
+
+    /// Converts the model to its BSON document representation.
+    pub fn to_bson(&self) -> Result<bson::Document> {
+        let mut doc = bson::Document::new();
+        doc.insert("key".to_owned(), Bson::Document(self.keys.clone()));
+
+        if let Some(ref val) = self.options.background {
+            doc.insert("background".to_owned(), Bson::Boolean(*val));
+        }
+        if let Some(ref val) = self.options.expire_after_seconds {
+            doc.insert("expireAfterSeconds".to_owned(), Bson::I32(*val));
+        }
+        if let Some(ref val) = self.options.name {
+            doc.insert("name".to_owned(), Bson::String(val.to_owned()));
+        } else {
+            doc.insert("name".to_owned(), Bson::String(try!(self.generate_index_name())));
+        }
+        if let Some(ref val) = self.options.sparse {
+            doc.insert("sparse".to_owned(), Bson::Boolean(*val));
+        }
+        if let Some(ref val) = self.options.storage_engine {
+            doc.insert("storageEngine".to_owned(), Bson::String(val.to_owned()));
+        }
+        if let Some(ref val) = self.options.unique {
+            doc.insert("unique".to_owned(), Bson::Boolean(*val));
+        }
+        if let Some(ref val) = self.options.version {
+            doc.insert("v".to_owned(), Bson::I32(*val));
+        }
+        if let Some(ref val) = self.options.default_language {
+            doc.insert("default_language".to_owned(), Bson::String(val.to_owned()));
+        }
+        if let Some(ref val) = self.options.language_override {
+            doc.insert("language_override".to_owned(), Bson::String(val.to_owned()));
+        }
+        if let Some(ref val) = self.options.text_version {
+            doc.insert("textIndexVersion".to_owned(), Bson::I32(*val));
+        }
+        if let Some(ref val) = self.options.weights {
+            doc.insert("weights".to_owned(), Bson::Document(val.clone()));
+        }
+        if let Some(ref val) = self.options.sphere_version {
+            doc.insert("2dsphereIndexVersion".to_owned(), Bson::I32(*val));
+        }
+        if let Some(ref val) = self.options.bits {
+            doc.insert("bits".to_owned(), Bson::I32(*val));
+        }
+        if let Some(ref val) = self.options.max {
+            doc.insert("max".to_owned(), Bson::FloatingPoint(*val));
+        }
+        if let Some(ref val) = self.options.min {
+            doc.insert("min".to_owned(), Bson::FloatingPoint(*val));
+        }
+        if let Some(ref val) = self.options.bucket_size {
+            doc.insert("bucketSize".to_owned(), Bson::I32(*val));
+        }
+
+        Ok(doc)
     }
 }
 

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -9,6 +9,7 @@ use Error::{self, ArgumentError, OperationError, PoisonLockError};
 use Result;
 
 use super::Store;
+use coll::options::IndexOptions;
 
 use std::{cmp, io, thread};
 use std::error::Error as ErrorTrait;
@@ -192,7 +193,13 @@ impl File {
                 }
                 self.doc.md5 = self.wsum.result_str();
                 try!(self.gfs.files.insert_one(self.doc.to_bson(), None));
-                try!(self.gfs.chunks.create_index(doc!{ "files_id" => 1, "n" => 1}, None));
+
+                // Ensure indexes
+                try!(self.gfs.files.create_index(doc!{ "filename" => 1 }, None));
+
+                let mut opts = IndexOptions::new();
+                opts.unique = Some(true);
+                try!(self.gfs.chunks.create_index(doc!{ "files_id" => 1, "n" => 1}, Some(opts)));
             } else {
                 try!(self.gfs.chunks.delete_many(doc!{ "files_id" => (self.doc.id.clone()) }, None));
             }

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -192,6 +192,7 @@ impl File {
                 }
                 self.doc.md5 = self.wsum.result_str();
                 try!(self.gfs.files.insert_one(self.doc.to_bson(), None));
+                try!(self.gfs.chunks.create_index(doc!{ "files_id" => 1, "n" => 1}, None));
             } else {
                 try!(self.gfs.chunks.delete_many(doc!{ "files_id" => (self.doc.id.clone()) }, None));
             }

--- a/tests/client/coll.rs
+++ b/tests/client/coll.rs
@@ -2,7 +2,8 @@ use bson::Bson;
 
 use mongodb::{Client, ThreadedClient};
 use mongodb::db::ThreadedDatabase;
-use mongodb::coll::options::{FindOptions, FindOneAndUpdateOptions, ReturnDocument};
+use mongodb::coll::options::{FindOptions, FindOneAndUpdateOptions,
+                             IndexModel, IndexOptions, ReturnDocument};
 
 #[test]
 fn find_sorted() {
@@ -10,7 +11,7 @@ fn find_sorted() {
     let db = client.db("test");
     let coll = db.collection("find_sorted");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert document
     let doc1 = doc! { "title" => "Jaws" };
@@ -53,7 +54,7 @@ fn find_and_insert() {
     let db = client.db("test");
     let coll = db.collection("find_and_insert");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
@@ -82,7 +83,7 @@ fn find_and_insert_one() {
     let db = client.db("test");
     let coll = db.collection("find_and_insert");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert document
     let doc = doc! { "title" => "Jaws" };
@@ -105,7 +106,7 @@ fn find_one_and_delete() {
     let db = client.db("test");
     let coll = db.collection("find_one_and_delete");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -145,7 +146,7 @@ fn find_one_and_replace() {
     let db = client.db("test");
     let coll = db.collection("find_one_and_replace");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -201,7 +202,7 @@ fn find_one_and_update() {
     let db = client.db("test");
     let coll = db.collection("find_one_and_update");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -242,7 +243,7 @@ fn aggregate() {
     let db = client.db("test");
     let coll = db.collection("aggregate");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "tags" => ["a", "b", "c"] };
@@ -288,7 +289,7 @@ fn count() {
     let db = client.db("test");
     let coll = db.collection("count");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -320,7 +321,7 @@ fn distinct_none() {
     let db = client.db("test");
     let coll = db.collection("distinct_none");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
     let distinct_titles = coll.distinct("title", None, None).ok().expect("Failed to execute 'distinct'.");
     assert_eq!(0, distinct_titles.len());
 }
@@ -331,7 +332,7 @@ fn distinct_one() {
     let db = client.db("test");
     let coll = db.collection("distinct_none");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
     let doc2 = doc! { "title" => "Back to the Future" };
     coll.insert_one(doc2, None).ok().expect("Failed to insert document.");
 
@@ -345,7 +346,7 @@ fn distinct() {
     let db = client.db("test");
     let coll = db.collection("distinct");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws",
@@ -403,7 +404,7 @@ fn insert_many() {
     let db = client.db("test");
     let coll = db.collection("insert_many");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -433,7 +434,7 @@ fn delete_one() {
     let db = client.db("test");
     let coll = db.collection("delete_one");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -465,7 +466,7 @@ fn delete_many() {
     let db = client.db("test");
     let coll = db.collection("delete_many");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -497,7 +498,7 @@ fn replace_one() {
     let db = client.db("test");
     let coll = db.collection("replace_one");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -534,7 +535,7 @@ fn update_one() {
     let db = client.db("test");
     let coll = db.collection("update_one");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -568,7 +569,7 @@ fn update_many() {
     let db = client.db("test");
     let coll = db.collection("update_many");
 
-    db.drop_database().ok().expect("Failed to drop database");
+    coll.drop().ok().expect("Failed to drop database");
 
     // Insert documents
     let doc1 = doc! { "title" => "Jaws" };
@@ -600,4 +601,106 @@ fn update_many() {
         Some(&Bson::String(ref director)) => assert_eq!("Robert Zemeckis", director),
         _ => panic!("Expected Bson::String for director!"),
     }
+}
+
+#[test]
+fn create_list_drop_indexes() {
+    let client = Client::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+    let coll = db.collection("create_list_drop_indexes");
+
+    coll.drop().ok().expect("Failed to drop database.");
+
+    let mut opts1 = IndexOptions::new();
+    opts1.name = Some("nid".to_owned());
+
+    // Test name option
+    let index1 = IndexModel::new(doc!{ "n" => 1, "id" => 1}, Some(opts1));
+
+    // Test negative value and index name generation
+    let index2 = IndexModel::new(doc!{ "test" => (-1), "height" => 1}, None);
+
+    coll.create_indexes(vec![index1, index2]).unwrap();
+    let mut cursor = coll.list_indexes().unwrap();
+    let results = cursor.next_n(5).unwrap();
+    
+    assert_eq!(3, results.len());
+
+    // Assert first inserted index
+    match results[1].get("key") {
+        Some(&Bson::Document(ref keys)) => {
+            match keys.get("n") {
+                Some(&Bson::I32(ref i)) => assert_eq!(1, *i),
+                _ => panic!("Expected key 'n => 1'."),
+            }
+            match keys.get("id") {
+                Some(&Bson::I32(ref i)) => assert_eq!(1, *i),
+                _ => panic!("Expected key 'id => 1'."),
+            }
+        },
+        _ => panic!("keys not found for first index."),
+    }
+
+    match results[1].get("name") {
+        Some(&Bson::String(ref name)) => assert_eq!("nid", name),
+        _ => panic!("Expected first index to have a name."),
+    }
+
+    // Assert second inserted index
+    match results[2].get("key") {
+        Some(&Bson::Document(ref keys)) => {
+            match keys.get("test") {
+                Some(&Bson::I32(ref i)) => assert_eq!(-1, *i),
+                _ => panic!("Expected key 'test => -1'."),
+            }
+            match keys.get("height") {
+                Some(&Bson::I32(ref i)) => assert_eq!(1, *i),
+                _ => panic!("Expected key 'height => 1'."),
+            }
+        },
+        _ => panic!("keys not found for second index."),
+    }
+
+    match results[2].get("name") {
+        Some(&Bson::String(ref name)) => assert_eq!("test_-1_height_1", name),
+        _ => panic!("Expected first index to have a name."),
+    }
+
+    // Drop and ensure
+    coll.drop_index_string("nid".to_owned()).unwrap();
+    let mut cursor = coll.list_indexes().unwrap();
+    let results = cursor.next_n(5).unwrap();
+
+    assert_eq!(2, results.len());
+
+    coll.drop_index(doc!{ "test" => (-1), "height" => 1 }, None).unwrap();
+    let mut cursor = coll.list_indexes().unwrap();
+    let results = cursor.next_n(5).unwrap();
+
+    assert_eq!(1, results.len());
+}
+
+#[test]
+fn drop_all_indexes() {
+    let client = Client::with_uri("mongodb://localhost:27017").unwrap();
+    let db = client.db("test");
+    let coll = db.collection("drop_all_indexes");
+
+    coll.drop().ok().expect("Failed to drop database.");
+
+    let mut opts1 = IndexOptions::new();
+    opts1.name = Some("nid".to_owned());
+
+    // Test name option
+    let index1 = IndexModel::new(doc!{ "n" => 1, "id" => 1}, Some(opts1));
+
+    // Test negative value and index name generation
+    let index2 = IndexModel::new(doc!{ "test" => (-1), "height" => 1}, None);
+
+    coll.create_indexes(vec![index1, index2]).unwrap();
+    coll.drop_indexes().unwrap();
+    let mut cursor = coll.list_indexes().unwrap();
+    let results = cursor.next_n(5).unwrap();
+    
+    assert_eq!(1, results.len());
 }

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -10,7 +10,7 @@ fn cursor_features() {
     let db = client.db("test");
     let coll = db.collection("cursor_test");
 
-    db.drop_database().ok().expect("Failed to drop database.");
+    coll.drop().ok().expect("Failed to drop database.");
 
     let docs = (0..10).map(|i| {
         doc! { "foo" => (i as i64) }

--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -1,7 +1,7 @@
 #[test]
 fn list_collections() {
     let client = Client::with_uri("mongodb://localhost:27017").unwrap();
-    let db = client.db("test");
+    let db = client.db("list_collections");
 
     db.drop_database().ok().expect("Failed to drop database");
 

--- a/tests/client/gridfs.rs
+++ b/tests/client/gridfs.rs
@@ -2,7 +2,7 @@ use bson::Bson;
 
 use mongodb::{Client, ThreadedClient};
 use mongodb::coll::Collection;
-use mongodb::coll::options::FindOptions;
+use mongodb::coll::options::{FindOptions, IndexOptions};
 use mongodb::db::ThreadedDatabase;
 use mongodb::gridfs::{Store, ThreadedStore};
 use mongodb::gridfs::file::DEFAULT_CHUNK_SIZE;
@@ -76,7 +76,9 @@ fn put_get() {
     let results = cursor.next_n(10).unwrap();
     assert_eq!(2, results.len());
 
-    fschunks.create_index(doc!{ "files_id" => 1, "n" => 1}, None).unwrap();
+    let mut opts = IndexOptions::new();
+    opts.unique = Some(true);
+    fschunks.create_index(doc!{ "files_id" => 1, "n" => 1}, Some(opts)).unwrap();
     let mut cursor = fschunks.list_indexes().unwrap();
     let results = cursor.next_n(10).unwrap();
     assert_eq!(2, results.len());

--- a/tests/client/gridfs.rs
+++ b/tests/client/gridfs.rs
@@ -53,6 +53,7 @@ fn put_get() {
     let mut opts = FindOptions::new();
     opts.sort = Some(doc!{ "n" => 1});
 
+    // Check chunks
     let mut cursor = fschunks.find(Some(doc!{"files_id" => (id.clone())}), Some(opts)).unwrap();
 
     let chunks = cursor.next_batch().ok().expect("Failed to get next batch");
@@ -70,6 +71,16 @@ fn put_get() {
         }
     }
 
+    // Ensure index
+    let mut cursor = fschunks.list_indexes().unwrap();
+    let results = cursor.next_n(10).unwrap();
+    assert_eq!(2, results.len());
+
+    fschunks.create_index(doc!{ "files_id" => 1, "n" => 1}, None).unwrap();
+    let mut cursor = fschunks.list_indexes().unwrap();
+    let results = cursor.next_n(10).unwrap();
+    assert_eq!(2, results.len());
+    
     // Get
     let mut dest = Vec::with_capacity(src_len);
     unsafe { dest.set_len(src_len) };

--- a/tests/client/wire_protocol.rs
+++ b/tests/client/wire_protocol.rs
@@ -1,12 +1,21 @@
 use bson::{Bson, Document};
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::{ThreadedDatabase};
 use mongodb::wire_protocol::flags::{OpInsertFlags, OpQueryFlags,
                                             OpUpdateFlags};
 use mongodb::wire_protocol::operations::Message;
 use std::io::Write;
 use std::net::TcpStream;
 
+fn drop_db() {
+    let client = Client::connect("localhost", 27017).unwrap();
+    let db = client.db("test");
+    db.drop_database().unwrap();
+}
+
 #[test]
 fn insert_single_key_doc() {
+    drop_db();
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! { "foo" => 42.0 };
@@ -68,6 +77,7 @@ fn insert_single_key_doc() {
 
 #[test]
 fn insert_multi_key_doc() {
+    drop_db();
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! {
@@ -137,6 +147,7 @@ fn insert_multi_key_doc() {
 
 #[test]
 fn insert_docs() {
+    drop_db();
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc1 = doc! {
@@ -217,6 +228,7 @@ fn insert_docs() {
 
 #[test]
 fn insert_update_then_query() {
+    drop_db();
     match TcpStream::connect("localhost:27017") {
         Ok(mut stream) => {
             let doc = doc! { "foo" => 42.0 };


### PR DESCRIPTION
Implements all create and drop index functions + `list_indexes()`. GridFS now uses `create_index` to speed up iteration over chunks.

Note that once the BSON Encoder/Decoder is built into bson-rs, `IndexModel.to_bson()` can be replaced by a one-liner, `bson::encode(model)`.

This PR also switches the tests to drop their collections instead of the entire database, and fixes the persistence of `wire_protocol` tests by using `drop_db`.