### PR TITLE
Made tests/client/db.rs actually used

### DIFF
--- a/tests/client/db.rs
+++ b/tests/client/db.rs
@@ -1,3 +1,7 @@
+use bson::{self, Bson};
+use mongodb::{Client, ThreadedClient};
+use mongodb::db::ThreadedDatabase;
+
 #[test]
 fn list_collections() {
     let client = Client::with_uri("mongodb://localhost:27017").unwrap();
@@ -15,7 +19,7 @@ fn list_collections() {
     let mut cursor = db.list_collections_with_batch_size(None, 1)
         .ok().expect("Failed to execute list_collections command.");;
 
-    let results = cursor.next_n(5);
+    let results = cursor.next_n(5).unwrap();
     assert_eq!(3, results.len());
 
     match results[0].get("name") {

--- a/tests/client/mod.rs
+++ b/tests/client/mod.rs
@@ -3,6 +3,7 @@ mod client;
 mod coll;
 mod connstring;
 mod crud_spec;
+mod db;
 mod cursor;
 mod error;
 mod gridfs;


### PR DESCRIPTION
Apparently `tests/client/db.rs` was never actually included in the test suite because it wasn't declared as a module in `tests/client/mod.rs`. This pull request fixes that (and a slight issue in the test that occured due to an API change since the test file was written).