### PR TITLE
Changed it so first test in set isn't dropped

### DIFF
--- a/tests/client/crud_spec/framework.rs
+++ b/tests/client/crud_spec/framework.rs
@@ -243,12 +243,10 @@ macro_rules! run_update_test {
 macro_rules! run_suite {
     ( $file:expr, $coll:expr ) => {{
         let json = Json::from_file($file).unwrap();
-        let mut suite = json.get_suite().unwrap();
+        let suite = json.get_suite().unwrap();
         let client =  Client::connect("localhost", 27017).unwrap();
         let db = client.db("test");
         let coll = db.collection($coll);
-
-        suite.tests.remove(0);
 
         for test in suite.tests {
             coll.drop().unwrap();


### PR DESCRIPTION
(I'm not proud of this one...)

Apparently for the entire time since it was first merged, the CRUD spec test suite has been dropping the first test from each set. As far as I can tell, I had it do that to run a certain test, and then forgot to take it out. Luckily, everything still passes.