### PR TITLE
Remove `Cursor::query`, change `query_with_batch_size` to `query`

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -161,10 +161,9 @@ impl Collection {
             filter.unwrap_or(bson::Document::new())
         };
 
-        Cursor::query_with_batch_size(self.db.client.clone(), self.namespace.to_owned(),
-                                      options.batch_size, flags, options.skip as i32,
-                                      options.limit, doc, options.projection.clone(),
-                                      false)
+        Cursor::query(self.db.client.clone(), self.namespace.to_owned(), options.batch_size,
+                      flags, options.skip as i32, options.limit, doc,
+                      options.projection.clone(), false)
     }
 
     /// Returns the first document within the collection that matches the filter, or None.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -45,9 +45,8 @@ impl Cursor {
     /// Returns the newly created Cursor on success, or an Error on failure.
     pub fn command_cursor(client: Client, db: &str,
                           doc: bson::Document) -> Result<Cursor> {
-        Cursor::query_with_batch_size(client.clone(), format!("{}.$cmd", db),
-                                      1, OpQueryFlags::no_flags(), 0, 0,
-                                      doc, None, true)
+        Cursor::query(client.clone(), format!("{}.$cmd", db), 1, OpQueryFlags::no_flags(), 0, 0,
+                      doc, None, true)
     }
 
     fn get_bson_and_cid_from_message(message: Message) -> Result<(VecDeque<bson::Document>, i64)> {
@@ -58,7 +57,7 @@ impl Cursor {
                 let mut v = VecDeque::new();
 
                 if !docs.is_empty() {
-                    if let Some(&Bson::I32(ref code)) = docs[0].get("code") {                        
+                    if let Some(&Bson::I32(ref code)) = docs[0].get("code") {
                         // If command doesn't exist or namespace not found, return
                         // an empty array instead of throwing an error.
                         if *code == ErrorCode::CommandNotFound as i32 ||
@@ -134,7 +133,7 @@ impl Cursor {
     ///
     /// Returns the cursor for the query results on success, or an Error on
     /// failure.
-    pub fn query_with_batch_size(client: Client, namespace: String,
+    pub fn query(client: Client, namespace: String,
                                  batch_size: i32, flags: OpQueryFlags,
                                  number_to_skip: i32, number_to_return: i32,
                                  query: bson::Document,
@@ -162,38 +161,6 @@ impl Cursor {
         Ok(Cursor { client: client, namespace: namespace,
                     batch_size: batch_size, cursor_id: cursor_id,
                     limit: number_to_return, count: 0, buffer: buf, })
-    }
-
-    /// Executes a query with the default batch size.
-    ///
-    /// # Arguments
-    ///
-    /// `client` - The client to read from.
-    /// `namespace` - The namespace to read and write from.
-    /// `flags` - Bit vector of query options.
-    /// `number_to_skip` - The number of initial documents to skip over in the
-    ///                    query results.
-    /// `number_to_return - The total number of documents that should be
-    ///                     returned by the query.
-    /// `query` - Specifies which documents to return.
-    /// `return_field_selector - An optional projection of which fields should
-    ///                          be present in the documents to be returned by
-    ///                          the query.
-    /// `is_cmd_cursor` - Whether or not the Cursor is for a database command.
-    ///
-    /// # Return value
-    ///
-    /// Returns the cursor for the query results on success, or an error string
-    /// on failure.
-    pub fn query(client: Client, namespace: String,
-                 flags: OpQueryFlags, number_to_skip: i32,
-                 number_to_return: i32, query: bson::Document,
-                 return_field_selector: Option<bson::Document>,
-                 is_cmd_cursor: bool) -> Result<Cursor> {
-        Cursor::query_with_batch_size(client.clone(), namespace, DEFAULT_BATCH_SIZE, flags,
-                                      number_to_skip,
-                                      number_to_return, query,
-                                      return_field_selector, is_cmd_cursor)
     }
 
     /// Helper method to create a "get more" request.

--- a/tests/client/cursor.rs
+++ b/tests/client/cursor.rs
@@ -21,9 +21,8 @@ fn cursor_features() {
     let doc = Document::new();
     let flags = OpQueryFlags::no_flags();
 
-    let result = Cursor::query_with_batch_size(client.clone(), "test.cursor_test".to_owned(),
-                                               3, flags,
-                                               0, 0, doc, None, false);
+    let result = Cursor::query(client.clone(), "test.cursor_test".to_owned(), 3, flags, 0, 0,
+                               doc, None, false);
 
     let mut cursor = match result {
         Ok(c) => c,


### PR DESCRIPTION
Since the method `Cursor::query` has never been used, it should be taken out, and the method `Cursor::query_with_batch_size` should be renamed to reflect this.