### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ dependencies = [
  "bson 0.1.2 (git+https://github.com/zonyitoo/bson-rs)",
  "byteorder 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nalgebra 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ authors = ["Valeri Karpov <valkar207@gmail.com>",
 [dependencies]
 byteorder = "0.3"
 chrono = "0.2"
-libc = "0.1"
-nalgebra = "0.2"
-rand = "0.3"
 rust-crypto = "0.2.31"
 rustc-serialize = "0.3"
 time = "0.1"
 
 [dependencies.bson]
 git = "https://github.com/zonyitoo/bson-rs"
-ref = "a62d7448682455642e759088138592a508c25150"
+ref = "1c1fcca2781f6a8947bbf1abe7b4bcbfba9e7ee3"
+
+[dev-dependencies]
+nalgebra = "0.2"
+rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@ extern crate bson;
 extern crate byteorder;
 extern crate chrono;
 extern crate crypto;
-extern crate libc;
-extern crate rand;
 extern crate rustc_serialize;
 extern crate time;
 


### PR DESCRIPTION
A few dependencies are no longer needed since the code using them is now in the BSON library, and a couple of dependencies are for testing only, so they belong in `dev-dependencies`.