### PR TITLE
Fix issues with tests caused by SDAM integration

### DIFF
--- a/tests/apm/mod.rs
+++ b/tests/apm/mod.rs
@@ -7,16 +7,18 @@ use mongodb::db::ThreadedDatabase;
 use rand;
 
 fn timed_query(_client: Client, command_result: &CommandResult) {
-    let duration = match command_result {
-        &CommandResult::Success { duration, .. } => duration,
+    let (command_name, duration) = match command_result {
+        &CommandResult::Success { ref command_name, duration, .. } => (command_name.clone(), duration),
         _ => panic!("Command failed!")
     };
 
-    // Sanity check
-    assert!(duration >= 500000000);
+    if command_name.eq("find") {
+        // Sanity check
+        assert!(duration >= 1500000000);
 
-    // Technically not guaranteed, but since the query is running locally, it shouldn't even be close
-    assert!(duration < 2000000000);
+        // Technically not guaranteed, but since the query is running locally, it shouldn't even be close
+        assert!(duration < 2000000000);
+    }
 }
 
 #[test]

--- a/tests/client/sdam/framework.rs
+++ b/tests/client/sdam/framework.rs
@@ -44,10 +44,7 @@ pub fn run_suite(file: &str, description: Option<TopologyDescription>) {
         topology_description.servers.insert(host.clone(), server);
     }
 
-    let mut i = 0;
     for phase in suite.phases {
-        i += 1;
-
         for (host, response) in phase.operation.data {
             {
                 // Save each seen server to replicate monitors for servers

--- a/tests/client/sdam/framework.rs
+++ b/tests/client/sdam/framework.rs
@@ -46,7 +46,6 @@ pub fn run_suite(file: &str, description: Option<TopologyDescription>) {
 
     let mut i = 0;
     for phase in suite.phases {
-        println!("Running phase {}", i);
         i += 1;
 
         for (host, response) in phase.operation.data {

--- a/tests/client/sdam/rs.rs
+++ b/tests/client/sdam/rs.rs
@@ -11,7 +11,6 @@ fn sdam_rs() {
         let path2 = path.unwrap().path();
         let filename = path2.to_string_lossy();
         if filename.ends_with(".json") {
-            println!("Running suite for {}", filename);
             run_suite(&filename, None)
         }
     }

--- a/tests/client/sdam/sharded.rs
+++ b/tests/client/sdam/sharded.rs
@@ -11,7 +11,6 @@ fn sdam_sharded() {
         let path2 = path.unwrap().path();
         let filename = path2.to_string_lossy();
         if filename.ends_with(".json") {
-            println!("Running suite for {}", filename);
             run_suite(&filename, None)
         }
     }

--- a/tests/client/sdam/single.rs
+++ b/tests/client/sdam/single.rs
@@ -13,7 +13,6 @@ fn sdam_single() {
         let path2 = path.unwrap().path();
         let filename = path2.to_string_lossy();
         if filename.ends_with(".json") {
-            println!("Running suite for {}", filename);
             let mut description = TopologyDescription::new();
             description.topology_type = TopologyType::Single;
             run_suite(&filename, Some(description))


### PR DESCRIPTION
Because of a particularly long-running `isMaster` command, the `command_duration` test was panicking; the test is revised to only check the `find` command, which was the original intention. It might be useful down the line to just suppress the `isMaster` commands from being emitted as events completely, since there will be a lot of them, and they aren't particularly useful (I've added the functionality for suppressed commands as part the authentication functionality for obvious reasons, so this would be very simple to do if we decide to go this route).

I also removed some print statements from the SDAM tests that could clutter the output if the tests are run with `-- --nocapture`, which be done for debugging if other tests are printing out more useful information.