### PR TITLE
Updated config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "mongodb"
 version = "0.1.0"
 dependencies = [
- "bson 0.1.2 (git+https://github.com/zonyitoo/bson-rs)",
+ "bson 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "nalgebra 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,8 +24,8 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "0.1.2"
-source = "git+https://github.com/zonyitoo/bson-rs#1c1fcca2781f6a8947bbf1abe7b4bcbfba9e7ee3"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,14 @@ version = "0.1.0"
 authors = ["Valeri Karpov <valkar207@gmail.com>",
            "Saghm Rossi <saghmrossi@gmail.com>",
            "Kevin Yeh <kevinyeah@utexas.edu>"]
+description = "An experimental MongoDB driver written by MongoDB interns."
+repository = "https://github.com/mongodbinc-interns/mongo-rust-driver-prototype"
+readme = "README.md"
+keywords = ["mongo", "mongodb", "database", "bson", "nosql"]
+license = "apache"
 
 [dependencies]
+bson = "0.1.3"
 byteorder = "0.3"
 chrono = "0.2"
 rand = "0.3"
@@ -16,7 +22,3 @@ time = "0.1"
 
 [dev-dependencies]
 nalgebra = "0.2"
-
-[dependencies.bson]
-git = "https://github.com/zonyitoo/bson-rs"
-ref = "1c1fcca2781f6a8947bbf1abe7b4bcbfba9e7ee3"


### PR DESCRIPTION
In anticipation of releasing this on crates.io in the next week or so (!), I've added some updates to `Cargo.toml`. It's probably better to start relying on the crated version of `bson` rather than the git version (especially since we've been working so closely with Y.T. on it, so there shouldn't be any issues where we need an update pushed that we can't get) . I also added a provision description and set of keywords, although I would not be at all surprised if you guys have suggestions on how to improve them before merging. For the keywords, we only have the option to choose up to five, and based on my completely non-rigorous testing, it seems that `crates.io` does *not* search for substrings of the keywords (hence the need for "mongo" AND "mongodb"). I basically just picked the first five that came to mind though, so feel free to suggest better ones.