### PR TITLE
Fix type mismatch on is_master result

### DIFF
--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -83,7 +83,9 @@ impl IsMasterResult {
     /// Parses an isMaster response document from the server.
     pub fn new(doc: bson::Document) -> Result<IsMasterResult> {
         let ok = match doc.get("ok") {
+            Some(&Bson::I32(v)) => if v == 0 { false } else { true },
             Some(&Bson::I64(v)) => if v == 0 { false } else { true },
+            Some(&Bson::FloatingPoint(v)) => if v == 0.0 { false } else { true },
             _ => return Err(ArgumentError("result does not contain `ok`.".to_owned())),
         };
 


### PR DESCRIPTION
Fixes a monitoring bug found by @saghm while building the import/export tool -- the server and topology information was not being updated, because the IsMasterResult would return `ok` as a FloatingPoint instead of an I64 like the automated tests.