### PR TITLE
Organized documentation and added module-level documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 authors = ["Valeri Karpov <valkar207@gmail.com>",
            "Saghm Rossi <saghmrossi@gmail.com>",
            "Kevin Yeh <kevinyeah@utexas.edu>"]
+
 description = "An experimental MongoDB driver written by MongoDB interns."
 repository = "https://github.com/mongodbinc-interns/mongo-rust-driver-prototype"
+documentation = "https://mongodbinc-interns.github.io/mongo-rust-driver-prototype/mongodb"
 readme = "README.md"
 keywords = ["mongo", "mongodb", "database", "bson", "nosql"]
 license = "apache"

--- a/src/apm/mod.rs
+++ b/src/apm/mod.rs
@@ -1,3 +1,9 @@
+//! Command Monitoring
+//!
+//! The APM module provides an intuitive interface for monitoring and responding to runtime information
+//! about commands being executed on the server. All non-suppressed commands trigger start and completion
+//! hooks defined on the client. Each non-suppressed command is also logged, if a log file was specified
+//! during instantiation of the client.
 pub mod client;
 mod event;
 mod listener;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,4 @@
+//! Authentication schemes.
 use bson::Bson::{self, Binary};
 use bson::Document;
 use bson::spec::BinarySubtype::Generic;
@@ -19,6 +20,7 @@ const B64_CONFIG : base64::Config = base64::Config { char_set: base64::Character
                                                      newline: base64::Newline::LF,
                                                      pad: true, line_length: None };
 
+/// Handles SCRAM-SHA-1 authentication logic.
 pub struct Authenticator {
     db: Database,
 }
@@ -37,10 +39,12 @@ struct AuthData {
 }
 
 impl Authenticator {
+    /// Creates a new authenticator.
     pub fn new(db: Database) -> Authenticator {
         Authenticator { db: db }
     }
 
+    /// Authenticates a user-password pair against a database.
     pub fn auth(self, user: &str, password: &str) -> Result<()> {
         let initial_data = try!(self.start(user));
         let conversation_id = initial_data.conversation_id.clone();

--- a/src/coll/batch.rs
+++ b/src/coll/batch.rs
@@ -1,3 +1,4 @@
+//! Models for collection-level batch operations.
 use super::options::WriteModel;
 
 use bson::Document;

--- a/src/coll/error.rs
+++ b/src/coll/error.rs
@@ -1,3 +1,4 @@
+//! Write errors for collection-level operations.
 use bson::{self, Bson};
 use super::options::WriteModel;
 use common::WriteConcern;

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -1,3 +1,4 @@
+//! Interface for collection-level operations.
 mod batch;
 pub mod error;
 pub mod options;
@@ -25,7 +26,9 @@ use std::iter::FromIterator;
 
 /// Interfaces with a MongoDB collection.
 pub struct Collection {
+    /// A reference to the database that spawned this collection.
     pub db: Database,
+    /// The namespace of this collection, formatted as db_name.coll_name.
     pub namespace: String,
     read_preference: ReadPreference,
     write_concern: WriteConcern,

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1,3 +1,4 @@
+//! Options for collection-level operations.
 use bson::{self, Bson};
 use cursor;
 use common::{ReadPreference, WriteConcern};
@@ -115,6 +116,7 @@ pub struct FindOneAndUpdateOptions {
 }
 
 /// Options for index operations.
+#[derive(Clone)]
 pub struct IndexOptions {
     pub background: Option<bool>,
     pub expire_after_seconds: Option<i32>,
@@ -139,17 +141,20 @@ pub struct IndexOptions {
 }
 
 /// A single index model.
+#[derive(Clone)]
 pub struct IndexModel {
     pub keys: bson::Document,
     pub options: IndexOptions,
 }
 
+/// Options for insertMany operations.
 #[derive(Clone)]
 pub struct InsertManyOptions {
     pub ordered: bool,
     pub write_concern: Option<WriteConcern>,
 }
 
+/// Options for update operations.
 #[derive(Clone)]
 pub struct UpdateOptions {
     pub upsert: bool,

--- a/src/coll/results.rs
+++ b/src/coll/results.rs
@@ -1,3 +1,4 @@
+//! Results for collection-level operations.
 use bson;
 use bson::Bson;
 use std::collections::BTreeMap;

--- a/src/command_type.rs
+++ b/src/command_type.rs
@@ -1,3 +1,6 @@
+//! Monitorable command types.
+
+/// Executable command types that can be monitored by the driver.
 #[derive(PartialEq, Eq, Clone)]
 pub enum CommandType {
     Aggregate,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+//! Library-wide utilities.
 use Error::{self, ArgumentError};
 use Result;
 
@@ -16,7 +17,7 @@ pub enum ReadMode {
     Nearest,
 }
 
-impl FromStr for ReadMode {   
+impl FromStr for ReadMode {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self> {
         Ok(match s {
@@ -63,10 +64,14 @@ impl ReadPreference {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteConcern {
-    pub w: i32,          // Write replication
-    pub w_timeout: i32,  // Used in conjunction with 'w'. Propagation timeout in ms.
-    pub j: bool,         // If true, will block until write operations have been committed to journal.
-    pub fsync: bool,     // If true and server is not journaling, blocks until server has synced all data files to disk.
+    /// Write replication
+    pub w: i32,
+    /// Used in conjunction with 'w'. Propagation timeout in ms.
+    pub w_timeout: i32,
+    /// If true, will block until write operations have been committed to journal.
+    pub j: bool,
+    /// If true and server is not journaling, blocks until server has synced all data files to disk.
+    pub fsync: bool,
 }
 
 impl WriteConcern {

--- a/src/connstring.rs
+++ b/src/connstring.rs
@@ -1,3 +1,4 @@
+//! Connection string parsing and options.
 use Result;
 use Error::ArgumentError;
 use std::ascii::AsciiExt;
@@ -9,8 +10,11 @@ pub const URI_SCHEME: &'static str = "mongodb://";
 /// Encapsulates the hostname and port of a host.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Host {
+    /// The hostname for this host.
     pub host_name: String,
+    /// The inter-process communication file path, if this is an IPC host.
     pub ipc: String,
+    /// The port to communicate on.
     pub port: u16,
 }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,15 +1,27 @@
 //! Iterable network cursor for MongoDB queries.
 //!
 //! ```no_run
-//! try!(coll.insert_one(doc!{ "spirit_animal" => "ferret" }, None));
+//! # #[macro_use] extern crate bson;
+//! # extern crate mongodb;
 //!
-//! let mut cursor = coll.find(None, None);
+//! # use mongodb::{Client, ThreadedClient};
+//! # use mongodb::db::ThreadedDatabase;
+//! # use bson::Bson;
+//!
+//! # fn main() {
+//! # let client = Client::connect("localhost", 27017).unwrap();
+//! # let coll = client.db("test").collection("info");
+//!
+//! coll.insert_one(doc!{ "spirit_animal" => "ferret" }, None).unwrap();
+//!
+//! let mut cursor = coll.find(None, None).unwrap();
 //! for result in cursor {
 //!     let doc = result.ok().expect("Received network error during cursor operations.");
 //!     if let Some(&Bson::String(ref value)) = doc.get("spirit_animal") {
 //!         println!("My spirit animal is {}", value);
 //!     }
 //! }
+//! # }
 //! ```
 use {Client, CommandType, Error, ErrorCode, Result, ThreadedClient};
 use apm::{CommandStarted, CommandResult, EventRunner};

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -3,15 +3,15 @@
 //! ```no_run
 //! # #[macro_use] extern crate bson;
 //! # extern crate mongodb;
-//!
+//! #
 //! # use mongodb::{Client, ThreadedClient};
 //! # use mongodb::db::ThreadedDatabase;
 //! # use bson::Bson;
-//!
+//! #
 //! # fn main() {
 //! # let client = Client::connect("localhost", 27017).unwrap();
 //! # let coll = client.db("test").collection("info");
-//!
+//! #
 //! coll.insert_one(doc!{ "spirit_animal" => "ferret" }, None).unwrap();
 //!
 //! let mut cursor = coll.find(None, None).unwrap();

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,3 +1,16 @@
+//! Iterable network cursor for MongoDB queries.
+//!
+//! ```no_run
+//! try!(coll.insert_one(doc!{ "spirit_animal" => "ferret" }, None));
+//!
+//! let mut cursor = coll.find(None, None);
+//! for result in cursor {
+//!     let doc = result.ok().expect("Received network error during cursor operations.");
+//!     if let Some(&Bson::String(ref value)) = doc.get("spirit_animal") {
+//!         println!("My spirit animal is {}", value);
+//!     }
+//! }
+//! ```
 use {Client, CommandType, Error, ErrorCode, Result, ThreadedClient};
 use apm::{CommandStarted, CommandResult, EventRunner};
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,41 @@
+//! Interface for database-level operations.
+//!
+//! # Usage
+//!
+//! The database API provides methods for opening, creating, deleting, and listing collections. It also handles
+//! user-level authentication over SCRAM-SHA-1.
+//!
+//! ## Collection Operations
+//!
+//! ```no_run
+//! let db = client.db("movies");
+//! try!(db.create_collection("action", None));
+//! let collection_names = try!(db.collection_names());
+//! assert!(!collection_names.is_empty());
+//! ```
+//!
+//! ## Authentication
+//!
+//! ```no_run
+//! let db = client.db("redacted");
+//! try!(db.create_user("saghm", "1234", None));
+//! try!(db.auth("saghm", "1234"));
+//!
+//! let success = try!(db.list_collections(None));
+//! ```
+//!
+//! ## Arbitrary Database Commands
+//!
+//! Any valid MongoDB database command can be sent to the server with the `command` and `command_cursor` functions.
+//!
+//! ```no_run
+//! let db = client.db("movies");
+//! let cmd = doc! { "connectionStatus" => 1 };
+//! let result = try!(db.command(cmd, CommandType::Suppressed, None));
+//! if let Some(&Bson::Document(ref doc)) = result.get("authInfo") {
+//!     // Read authentication info.
+//! }
+//! ```
 pub mod options;
 pub mod roles;
 
@@ -16,9 +54,13 @@ use std::sync::Arc;
 
 /// Interfaces with a MongoDB database.
 pub struct DatabaseInner {
+    /// The database name.
     pub name: String,
+    /// A reference to the client that spawned this database.
     pub client: Client,
+    /// Indicates how a server should be selected for read operations.
     pub read_preference: ReadPreference,
+    /// Describes the guarantees provided by MongoDB when reporting the success of a write operation.
     pub write_concern: WriteConcern,
 }
 
@@ -28,37 +70,57 @@ pub trait ThreadedDatabase {
     /// Creates a database representation with optional read and write controls.
     fn open(client: Client, name: &str, read_preference: Option<ReadPreference>,
             write_concern: Option<WriteConcern>) -> Database;
+    /// Logs in a user using the SCRAM-SHA-1 mechanism.
     fn auth(&self, user: &str, password: &str) -> Result<()>;
+    /// Creates a collection representation with inherited read and write controls.
     fn collection(&self, coll_name: &str) -> Collection;
+    /// Creates a collection representation with custom read and write controls.
     fn collection_with_prefs(&self, coll_name: &str, create: bool,
                              read_preference: Option<ReadPreference>,
                              write_concern: Option<WriteConcern>) -> Collection;
+    /// Return a unique operational request id.
     fn get_req_id(&self) -> i32;
+    /// Generates a cursor for a relevant operational command.
     fn command_cursor(&self, spec: bson::Document, cmd_type: CommandType,
                       read_pref: ReadPreference) -> Result<Cursor>;
+    /// Sends an administrative command over find_one.
     fn command(&self, spec: bson::Document, cmd_type: CommandType,
                read_preference: Option<ReadPreference>) -> Result<bson::Document>;
+    /// Returns a list of collections within the database.
     fn list_collections(&self, filter: Option<bson::Document>) -> Result<Cursor>;
+    /// Returns a list of collections within the database with a custom batch size.
     fn list_collections_with_batch_size(&self, filter: Option<bson::Document>,
                                         batch_size: i32) -> Result<Cursor>;
+    /// Returns a list of collection names within the database.
     fn collection_names(&self, filter: Option<bson::Document>) -> Result<Vec<String>>;
+    /// Creates a new collection.
+    ///
+    /// Note that due to the implicit creation of collections during insertion, this
+    /// method should only be used to instantiate capped collections.
     fn create_collection(&self, name: &str,
                          options: Option<CreateCollectionOptions>) -> Result<()>;
+    /// Creates a new user.
     fn create_user(&self, name: &str, password: &str,
                    options: Option<CreateUserOptions>) -> Result<()>;
+    /// Permanently deletes all users from the database.
     fn drop_all_users(&self, write_concern: Option<WriteConcern>) -> Result<(i32)>;
+    /// Permanently deletes the collection from the database.
     fn drop_collection(&self, name: &str) -> Result<()>;
+    /// Permanently deletes the database from the server.
     fn drop_database(&self) -> Result<()>;
+    /// Permanently deletes the user from the database.
     fn drop_user(&self, name: &str, Option<WriteConcern>) -> Result<()>;
+    /// Retrieves information about all users in the database.
     fn get_all_users(&self, show_credentials: bool) -> Result<Vec<bson::Document>>;
+    /// Retrieves information about a given user from the database.
     fn get_user(&self, user: &str,
                 options: Option<UserInfoOptions>) -> Result<bson::Document>;
+    /// Retrieves information about a given set of users from the database.
     fn get_users(&self, users: Vec<&str>,
                  options: Option<UserInfoOptions>) -> Result<Vec<bson::Document>>;
 }
 
 impl ThreadedDatabase for Database {
-    /// Creates a database representation with optional read and write controls.
     fn open(client: Client, name: &str, read_preference: Option<ReadPreference>,
             write_concern: Option<WriteConcern>) -> Database {
         let rp = read_preference.unwrap_or(client.read_preference.to_owned());
@@ -72,36 +134,30 @@ impl ThreadedDatabase for Database {
         })
     }
 
-    /// Logs in a user using the SCRAM-SHA-1 mechanism
     fn auth(&self, user: &str, password: &str) -> Result<()> {
         let authenticator = Authenticator::new(self.clone());
         authenticator.auth(user, password)
     }
 
-    /// Creates a collection representation with inherited read and write controls.
     fn collection(&self, coll_name: &str) -> Collection {
         Collection::new(self.clone(), coll_name, false, Some(self.read_preference.to_owned()), Some(self.write_concern.to_owned()))
     }
 
-    /// Creates a collection representation with custom read and write controls.
     fn collection_with_prefs(&self, coll_name: &str, create: bool,
                              read_preference: Option<ReadPreference>,
                              write_concern: Option<WriteConcern>) -> Collection {
         Collection::new(self.clone(), coll_name, create, read_preference, write_concern)
     }
 
-    /// Return a unique operational request id.
     fn get_req_id(&self) -> i32 {
         self.client.get_req_id()
     }
 
-    /// Generates a cursor for a relevant operational command.
     fn command_cursor(&self, spec: bson::Document, cmd_type: CommandType,
                       read_pref: ReadPreference) -> Result<Cursor> {
         Cursor::command_cursor(self.client.clone(), &self.name[..], spec, cmd_type, read_pref)
     }
 
-    /// Sends an administrative command over find_one.
     fn command(&self, spec: bson::Document, cmd_type: CommandType,
                read_preference: Option<ReadPreference>) -> Result<bson::Document> {
 
@@ -114,7 +170,6 @@ impl ThreadedDatabase for Database {
         res.ok_or(OperationError(format!("Failed to execute command with spec {:?}.", spec)))
     }
 
-    /// Returns a list of collections within the database.
     fn list_collections(&self, filter: Option<bson::Document>) -> Result<Cursor> {
         self.list_collections_with_batch_size(filter, DEFAULT_BATCH_SIZE)
     }
@@ -135,8 +190,6 @@ impl ThreadedDatabase for Database {
         self.command_cursor(spec, CommandType::ListCollections, self.read_preference.to_owned())
     }
 
-
-    /// Returns a list of collection names within the database.
     fn collection_names(&self, filter: Option<bson::Document>) -> Result<Vec<String>> {
         let mut cursor = try!(self.list_collections(filter));
         let mut results = vec![];
@@ -151,10 +204,6 @@ impl ThreadedDatabase for Database {
         }
     }
 
-    /// Creates a new collection.
-    ///
-    /// Note that due to the implicit creation of collections during insertion, this
-    /// method should only be used to instantiate capped collections.
     fn create_collection(&self, name: &str,
                          options: Option<CreateCollectionOptions>) -> Result<()> {
         let coll_options = options.unwrap_or(CreateCollectionOptions::new());
@@ -180,7 +229,6 @@ impl ThreadedDatabase for Database {
         self.command(doc, CommandType::CreateCollection, None).map(|_| ())
     }
 
-    /// Creates a new user.
     fn create_user(&self, name: &str, password: &str,
                    options: Option<CreateUserOptions>) -> Result<()> {
         let user_options = options.unwrap_or(CreateUserOptions::new());
@@ -202,7 +250,6 @@ impl ThreadedDatabase for Database {
         self.command(doc, CommandType::CreateUser, None).map(|_| ())
     }
 
-    /// Permanently deletes all users from the database.
     fn drop_all_users(&self, write_concern: Option<WriteConcern>) -> Result<(i32)> {
         let mut doc = doc! { "dropAllUsersFromDatabase" => 1 };
 
@@ -219,7 +266,6 @@ impl ThreadedDatabase for Database {
         }
     }
 
-    /// Permanently deletes the collection from the database.
     fn drop_collection(&self, name: &str) -> Result<()> {
         let mut spec = bson::Document::new();
         spec.insert("drop".to_owned(), Bson::String(name.to_owned()));
@@ -227,8 +273,6 @@ impl ThreadedDatabase for Database {
         Ok(())
     }
 
-
-    /// Permanently deletes the database from the server.
     fn drop_database(&self) -> Result<()> {
         let mut spec = bson::Document::new();
         spec.insert("dropDatabase".to_owned(), Bson::I32(1));
@@ -236,7 +280,6 @@ impl ThreadedDatabase for Database {
         Ok(())
     }
 
-    /// Permanently deletes the user from the database.
     fn drop_user(&self, name: &str, write_concern: Option<WriteConcern>) -> Result<()> {
         let mut doc = doc! { "dropUser" => name };
 
@@ -247,7 +290,6 @@ impl ThreadedDatabase for Database {
         self.command(doc, CommandType::DropUser, None).map(|_| ())
     }
 
-    /// Retrieves information about all users in the database.
     fn get_all_users(&self, show_credentials: bool) -> Result<Vec<bson::Document>> {
         let doc = doc! {
             "usersInfo" => 1,
@@ -272,7 +314,6 @@ impl ThreadedDatabase for Database {
         Ok(users)
     }
 
-    /// Retrives information about a given user from the database.
     fn get_user(&self, user: &str,
                 options: Option<UserInfoOptions>) -> Result<bson::Document> {
         let info_options = options.unwrap_or(UserInfoOptions::new());
@@ -299,7 +340,6 @@ impl ThreadedDatabase for Database {
         }
     }
 
-    /// Retrives information about a given set of users from the database.
     fn get_users(&self, users: Vec<&str>,
                  options: Option<UserInfoOptions>) -> Result<Vec<bson::Document>> {
         let info_options = options.unwrap_or(UserInfoOptions::new());

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -11,7 +11,7 @@
 //! # use mongodb::{Client, ThreadedClient};
 //! # use mongodb::db::ThreadedDatabase;
 //! # let client = Client::connect("localhost", 27017).unwrap();
-//!
+//! #
 //! let db = client.db("movies");
 //! db.create_collection("action", None).unwrap();
 //! let collection_names = db.collection_names(None).unwrap();
@@ -24,7 +24,7 @@
 //! # use mongodb::{Client, ThreadedClient};
 //! # use mongodb::db::ThreadedDatabase;
 //! # let client = Client::connect("localhost", 27017).unwrap();
-//!
+//! #
 //! let db = client.db("redacted");
 //! db.create_user("saghm", "1234", None).unwrap();
 //! db.auth("saghm", "1234").unwrap();
@@ -39,13 +39,13 @@
 //! ```no_run
 //! # #[macro_use] extern crate bson;
 //! # extern crate mongodb;
-//!
+//! #
 //! # use mongodb::{Client, CommandType, ThreadedClient};
 //! # use mongodb::db::ThreadedDatabase;
 //! # use bson::Bson;
 //! # fn main() {
 //! # let client = Client::connect("localhost", 27017).unwrap();
-//!
+//! #
 //! let db = client.db("movies");
 //! let cmd = doc! { "connectionStatus" => 1 };
 //! let result = db.command(cmd, CommandType::Suppressed, None).unwrap();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -8,20 +8,28 @@
 //! ## Collection Operations
 //!
 //! ```no_run
+//! # use mongodb::{Client, ThreadedClient};
+//! # use mongodb::db::ThreadedDatabase;
+//! # let client = Client::connect("localhost", 27017).unwrap();
+//!
 //! let db = client.db("movies");
-//! try!(db.create_collection("action", None));
-//! let collection_names = try!(db.collection_names());
+//! db.create_collection("action", None).unwrap();
+//! let collection_names = db.collection_names(None).unwrap();
 //! assert!(!collection_names.is_empty());
 //! ```
 //!
 //! ## Authentication
 //!
 //! ```no_run
-//! let db = client.db("redacted");
-//! try!(db.create_user("saghm", "1234", None));
-//! try!(db.auth("saghm", "1234"));
+//! # use mongodb::{Client, ThreadedClient};
+//! # use mongodb::db::ThreadedDatabase;
+//! # let client = Client::connect("localhost", 27017).unwrap();
 //!
-//! let success = try!(db.list_collections(None));
+//! let db = client.db("redacted");
+//! db.create_user("saghm", "1234", None).unwrap();
+//! db.auth("saghm", "1234").unwrap();
+//!
+//! let success = db.list_collections(None).unwrap();
 //! ```
 //!
 //! ## Arbitrary Database Commands
@@ -29,12 +37,22 @@
 //! Any valid MongoDB database command can be sent to the server with the `command` and `command_cursor` functions.
 //!
 //! ```no_run
+//! # #[macro_use] extern crate bson;
+//! # extern crate mongodb;
+//!
+//! # use mongodb::{Client, CommandType, ThreadedClient};
+//! # use mongodb::db::ThreadedDatabase;
+//! # use bson::Bson;
+//! # fn main() {
+//! # let client = Client::connect("localhost", 27017).unwrap();
+//!
 //! let db = client.db("movies");
 //! let cmd = doc! { "connectionStatus" => 1 };
-//! let result = try!(db.command(cmd, CommandType::Suppressed, None));
+//! let result = db.command(cmd, CommandType::Suppressed, None).unwrap();
 //! if let Some(&Bson::Document(ref doc)) = result.get("authInfo") {
 //!     // Read authentication info.
 //! }
+//! # }
 //! ```
 pub mod options;
 pub mod roles;

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -1,3 +1,4 @@
+//! Options for database-level commands.
 use bson::Document;
 use common::WriteConcern;
 use db::roles::Role;

--- a/src/db/roles.rs
+++ b/src/db/roles.rs
@@ -1,3 +1,4 @@
+//! Role-based database and command authorization.
 use std::string::ToString;
 
 use bson::Bson;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+//! MongoDB Errors and Error Codes.
 use bson::{self, oid};
 use byteorder;
 use coll::error::{WriteException, BulkWriteException};

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -1,3 +1,4 @@
+//! Lower-level file and chunk representations in GridFS.
 use bson::{self, Bson, oid};
 use bson::spec::BinarySubtype;
 
@@ -264,7 +265,7 @@ impl File {
     }
 
     // Retrieves a binary file chunk from GridFS.
-    fn find_chunk(&mut self, id: oid::ObjectId, chunk_num: i32) -> Result<Vec<u8>> {
+    pub fn find_chunk(&mut self, id: oid::ObjectId, chunk_num: i32) -> Result<Vec<u8>> {
         let filter = doc!{"files_id" => id, "n" => chunk_num };
         match try!(self.gfs.chunks.find_one(Some(filter), None)) {
             Some(doc) => match doc.get("data") {

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -13,14 +13,19 @@
 //! you want access without having to load the entire file into memory.
 //!
 //! ```no_run
-//! let client = Client::connect("localhost", 27017);
+//! # use mongodb::{Client, ThreadedClient};
+//! # use mongodb::gridfs::{Store, ThreadedStore};
+//!
+//! let client = Client::connect("localhost", 27017).unwrap();
 //! let db = client.db("grid");
 //! let fs = Store::with_db(db.clone());
 //!
-//! try!(fs.put("/path/to/local_file.mp4"));
-//! let file = try!(fs.open("/path/to/local_file.mp4"));
-//! let chunk_bytes = try!(file.find_chunk(file.doc.id.clone(), 5));
-//! try!(file.close());
+//! fs.put("/path/to/local_file.mp4".to_owned()).unwrap();
+//! let mut file = fs.open("/path/to/local_file.mp4".to_owned()).unwrap();
+//!
+//! let id = file.doc.id.clone();
+//! let chunk_bytes = file.find_chunk(id, 5).unwrap();
+//! file.close().unwrap();
 //! ```
 pub mod file;
 

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -15,7 +15,7 @@
 //! ```no_run
 //! # use mongodb::{Client, ThreadedClient};
 //! # use mongodb::gridfs::{Store, ThreadedStore};
-//!
+//! #
 //! let client = Client::connect("localhost", 27017).unwrap();
 //! let db = client.db("grid");
 //! let fs = Store::with_db(db.clone());

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -1,3 +1,27 @@
+//! Specification for storing and retrieving files that exceed 16MB within MongoDB.
+//!
+//! Instead of storing a file in a single document, GridFS divides a file into parts, or chunks,
+//! and stores each of those chunks as a separate document. By default GridFS limits chunk size to 255k.
+//! GridFS uses two collections to store files. One collection stores the file chunks, and the other
+//! stores file metadata.
+
+//! When you query a GridFS store for a file, the driver or client will reassemble the chunks as needed.
+//! You can perform range queries on files stored through GridFS. You also can access information from
+//! arbitrary sections of files, which allows you to “skip” into the middle of a video or audio file.
+
+//! GridFS is useful not only for storing files that exceed 16MB but also for storing any files for which
+//! you want access without having to load the entire file into memory.
+//!
+//! ```no_run
+//! let client = Client::connect("localhost", 27017);
+//! let db = client.db("grid");
+//! let fs = Store::with_db(db.clone());
+//!
+//! try!(fs.put("/path/to/local_file.mp4"));
+//! let file = try!(fs.open("/path/to/local_file.mp4"));
+//! let chunk_bytes = try!(file.find_chunk(file.doc.id.clone(), 5));
+//! try!(file.close());
+//! ```
 pub mod file;
 
 use bson::{self, oid};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```no_run
 //! # use mongodb::{Client, ClientOptions, ThreadedClient};
 //! # use mongodb::common::{ReadMode, ReadPreference};
-//!
+//! #
 //! // Direct connection to a server. Will not look for other servers in the topology.
 //! let client = Client::connect("localhost", 27017)
 //!     .ok().expect("Failed to initialize client.");
@@ -34,14 +34,14 @@
 //! # use mongodb::{Client, ThreadedClient};
 //! # use mongodb::db::ThreadedDatabase;
 //! # use bson::Bson;
-//!
+//! #
 //! # fn main() {
 //! # let client = Client::connect("localhost", 27017).unwrap();
-//!
+//! #
 //! let coll = client.db("media").collection("movies");
-//! coll.insert_one(doc!{ "title" => "Back to the Future" }, None).ok().expect("Failed to insert.");
-//! coll.update_one(doc!{}, doc!{ "director" => "Robert Zemeckis" }, None).ok().expect("Failed to update.");
-//! coll.delete_many(doc!{}, None).ok().expect("Failed to delete.");
+//! coll.insert_one(doc!{ "title" => "Back to the Future" }, None).unwrap();
+//! coll.update_one(doc!{}, doc!{ "director" => "Robert Zemeckis" }, None).unwrap();
+//! coll.delete_many(doc!{}, None).unwrap();
 //!
 //! let mut cursor = coll.find(None, None).unwrap();
 //! for result in cursor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,88 @@
-#[macro_use(bson, doc)] extern crate bson;
+//! # MongoDB Rust Driver
+//!
+//! A driver written in pure Rust, providing a native interface to MongoDB.
+//!
+//! ## Connecting to MongoDB
+//!
+//! The Client is an entry-point to interacting with a MongoDB instance.
+//!
+//! ```no_run
+//! // Direct connection to a server. Will not look for other servers in the topology.
+//! let client = Client::connect("localhost", 27017)
+//!     .ok().expect("Failed to initialize client.");
+//!
+//! // Connect to a complex server topology, such as a replica set
+//! // or sharded cluster, using a connection string uri.
+//! let client = Client::with_uri("mongodb://localhost:27017,localhost:27018/")
+//!     .ok().expect("Failed to initialize client.");
+//!
+//! // Specify a read preference, and rely on the driver to find secondaries.
+//! let mut options = ClientOptions::new();
+//! options.read_preference = Some(ReadPreference::new(ReadMode::SecondaryPreferred, None));
+//! let client = Client::with_uri_and_options("mongodb://localhost:27017/", options)
+//!     .ok().expect("Failed to initialize client.");
+//! ```
+//! 
+//! ## Interacting with MongoDB Collections
+//!
+//! ```no_run
+//! let coll = client.db("media").coll("movies");
+//! try!(coll.insert_one(doc!{ "title" => "Back to the Future" }, None));
+//! try!(coll.update_one(doc!{}, doc!{ "director" => "Robert Zemeckis" }, None));
+//! try!(coll.delete_many(doc!{}, None));
+//!
+//! let mut cursor = try!(coll.find(None, None));
+//! for result in cursor {
+//!     if let Ok(item) = result {
+//!         if let Some(&Bson::String(ref title)) = item.get("title") {
+//!             println!("title: {}", title);
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Command Monitoring
+//!
+//! The driver provides an intuitive interface for monitoring and responding to runtime information
+//! about commands being executed on the server. Arbitrary functions can be used as start and
+//! completion hooks, reacting to command results from the server.
+//!
+//! ```no_run
+//! fn log_query_duration(client: Client, command_result: &CommandResult) {
+//!     match command_result {
+//!         &CommandResult::Success { ref command_name, duration, .. } => {
+//!             println!("{}: {} nanoseconds." stringify!(command_name), duration);
+//!         },
+//!         _ => println!("Failed to execute command."),
+//!     }
+//! }
+//!
+//! try!(client.add_completion_cook(log_query_duration));
+//! ```
+//!
+//! ## Topology Monitoring
+//!
+//! Each server within a MongoDB server set is monitored asynchronously for changes in status, and the
+//! driver's view of the current topology is updated in response to this. This allows the driver to be
+//! aware of the status of the server set it is communicating with, and to make server selections
+//! appropriately with regards to the user-specified ReadPreference and WriteConcern.
+//!
+//! ## Connection Pooling
+//!
+//! Each server within a MongoDB server set is maintained by the driver with a separate connection
+//! pool. By default, each pool has a maximum of 5 concurrent open connections.
+
+#[doc(html_root_url = "https://mongodbinc-interns.github.io/mongo-rust-driver-prototype")]
+
+#[macro_use(bson, doc)]
+extern crate bson;
 extern crate byteorder;
 extern crate chrono;
 extern crate crypto;
 extern crate rand;
 extern crate rustc_serialize;
-#[macro_use] extern crate scan_fmt;
+#[macro_use]
+extern crate scan_fmt;
 extern crate separator;
 extern crate textnonce;
 extern crate time;
@@ -47,21 +125,29 @@ use topology::server::Server;
 
 /// Interfaces with a MongoDB server or replica set.
 pub struct ClientInner {
+    /// Indicates how a server should be selected for read operations.
+    pub read_preference: ReadPreference,
+    /// Describes the guarantees provided by MongoDB when reporting the success of a write operation.
+    pub write_concern: WriteConcern,
     req_id: Arc<AtomicIsize>,
     topology: Topology,
     listener: Listener,
-    pub read_preference: ReadPreference,
-    pub write_concern: WriteConcern,
     log_file: Option<Mutex<File>>,
 }
 
 /// Configuration options for a client.
 pub struct ClientOptions {
+    /// File path for command logging.
     pub log_file: Option<String>,
+    /// Client-level server selection preferences for read operations.
     pub read_preference: Option<ReadPreference>,
+    /// Client-level write guarantees when reporting a write success.
     pub write_concern: Option<WriteConcern>,
+    /// Frequency of server monitor updates; default 10000 ms.
     pub heartbeat_frequency_ms: u32,
+    /// Timeout for selecting an appropriate server for operations; default 30000 ms.
     pub server_selection_timeout_ms: i64,
+    /// The size of the latency window for selecting suitable servers; default 15 ms.
     pub local_threshold_ms: i64,
 }
 
@@ -87,55 +173,65 @@ impl ClientOptions {
 }
 
 pub trait ThreadedClient: Sync + Sized {
+    /// Creates a new Client directly connected to a single MongoDB server.
     fn connect(host: &str, port: u16) -> Result<Self>;
+    /// Creates a new Client directly connected to a single MongoDB server with options.
     fn connect_with_options(host: &str, port: u16, ClientOptions) -> Result<Self>;
+    /// Creates a new Client connected to a complex topology, such as a
+    /// replica set or sharded cluster.
     fn with_uri(uri: &str) -> Result<Self>;
+    /// Creates a new Client connected to a complex topology, such as a
+    /// replica set or sharded cluster, with options.
     fn with_uri_and_options(uri: &str, options: ClientOptions) -> Result<Self>;
+    /// Create a new Client with manual connection configurations.
+    /// `connect` and `with_uri` should generally be used as higher-level constructors.
     fn with_config(config: ConnectionString, options: Option<ClientOptions>,
                    description: Option<TopologyDescription>) -> Result<Self>;
+    /// Creates a database representation.
     fn db<'a>(&'a self, db_name: &str) -> Database;
+    /// Creates a database representation with custom read and write controls.
     fn db_with_prefs(&self, db_name: &str, read_preference: Option<ReadPreference>,
                      write_concern: Option<WriteConcern>) -> Database;
+    /// Acquires a connection stream from the pool, along with slave_ok and should_send_read_pref.
     fn acquire_stream(&self, read_pref: ReadPreference) -> Result<(PooledStream, bool, bool)>;
+    /// Acquires a connection stream from the pool for write operations.
     fn acquire_write_stream(&self) -> Result<PooledStream>;
+    /// Returns a unique operational request id.
     fn get_req_id(&self) -> i32;
+    /// Returns a list of all database names that exist on the server.
     fn database_names(&self) -> Result<Vec<String>>;
+    /// Drops the database defined by `db_name`.
     fn drop_database(&self, db_name: &str) -> Result<()>;
+    /// Reports whether this instance is a primary, master, mongos, or standalone mongod instance.
     fn is_master(&self) -> Result<bool>;
+    /// Sets a function to be run every time a command starts.
     fn add_start_hook(&mut self, hook: fn(Client, &CommandStarted)) -> Result<()>;
+    /// Sets a function to be run every time a command completes.
     fn add_completion_hook(&mut self, hook: fn(Client, &CommandResult)) -> Result<()>;
 }
 
 pub type Client = Arc<ClientInner>;
 
 impl ThreadedClient for Client {
-    /// Creates a new Client connected to a single MongoDB server.
     fn connect(host: &str, port: u16) -> Result<Client> {
         let config = ConnectionString::new(host, port);
         let mut description = TopologyDescription::new();
         description.topology_type = TopologyType::Single;
-
         Client::with_config(config, None, Some(description))
     }
 
-    /// Creates a new Client connected to a single MongoDB server with a custom configuration.
     fn connect_with_options(host: &str, port: u16, options: ClientOptions) -> Result<Client> {
         let config = ConnectionString::new(host, port);
         let mut description = TopologyDescription::new();
         description.topology_type = TopologyType::Single;
-
         Client::with_config(config, Some(options), Some(description))
     }
 
-    /// Creates a new Client connected to a server or replica set using
-    /// a MongoDB connection string URI as defined by
-    /// [the manual](http://docs.mongodb.org/manual/reference/connection-string/).
     fn with_uri(uri: &str) -> Result<Client> {
         let config = try!(connstring::parse(uri));
         Client::with_config(config, None, None)
     }
 
-    /// Creates a new Client connected to a server or replica set with a custom configuration.
     fn with_uri_and_options(uri: &str, options: ClientOptions) -> Result<Client> {
         let config = try!(connstring::parse(uri));
         Client::with_config(config, Some(options), None)
@@ -185,33 +281,27 @@ impl ThreadedClient for Client {
         Ok(client)
     }
 
-    /// Creates a database representation with default read and write controls.
     fn db(&self, db_name: &str) -> Database {
         Database::open(self.clone(), db_name, None, None)
     }
 
-    /// Creates a database representation with custom read and write controls.
     fn db_with_prefs(&self, db_name: &str, read_preference: Option<ReadPreference>,
                      write_concern: Option<WriteConcern>) -> Database {
         Database::open(self.clone(), db_name, read_preference, write_concern)
     }
 
-    /// Acquires a connection stream from the pool, along with slave_ok and should_send_read_pref.
     fn acquire_stream(&self, read_preference: ReadPreference) -> Result<(PooledStream, bool, bool)> {
         self.topology.acquire_stream(read_preference)
     }
 
-    /// Acquires a connection stream from the pool for write operations.
     fn acquire_write_stream(&self) -> Result<PooledStream> {
         self.topology.acquire_write_stream()
     }
 
-    /// Returns a unique operational request id.
     fn get_req_id(&self) -> i32 {
         self.req_id.fetch_add(1, Ordering::SeqCst) as i32
     }
 
-    /// Returns a list of all database names that exist on the server.
     fn database_names(&self) -> Result<Vec<String>> {
         let mut doc = bson::Document::new();
         doc.insert("listDatabases".to_owned(), Bson::I32(1));
@@ -234,14 +324,12 @@ impl ThreadedClient for Client {
         Err(ResponseError("Server reply does not contain 'databases'.".to_owned()))
     }
 
-    /// Drops the database defined by `db_name`.
     fn drop_database(&self, db_name: &str) -> Result<()> {
         let db = self.db(db_name);
         try!(db.drop_database());
         Ok(())
     }
 
-    /// Reports whether this instance is a primary, master, mongos, or standalone mongod instance.
     fn is_master(&self) -> Result<bool> {
         let mut doc = bson::Document::new();
         doc.insert("isMaster".to_owned(), Bson::I32(1));
@@ -255,12 +343,10 @@ impl ThreadedClient for Client {
         }
     }
 
-    /// Sets a function to be run every time a command starts.
     fn add_start_hook(&mut self, hook: fn(Client, &CommandStarted)) -> Result<()> {
         self.listener.add_start_hook(hook)
     }
 
-    /// Sets a function to be run every time a command completes.
     fn add_completion_hook(&mut self, hook: fn(Client, &CommandResult)) -> Result<()> {
         self.listener.add_completion_hook(hook)
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,3 +1,4 @@
+//! Connection pooling for a single MongoDB server.
 use Error::{ArgumentError, OperationError};
 use Result;
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1,3 +1,4 @@
+//! MongoDB server set topology and asynchronous monitoring.
 pub mod server;
 pub mod monitor;
 

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -1,3 +1,4 @@
+//! Asynchronous server and topology discovery and monitoring using isMaster results.
 use {Client, Result};
 use Error::{self, ArgumentError, OperationError};
 

--- a/src/topology/server.rs
+++ b/src/topology/server.rs
@@ -1,3 +1,4 @@
+//! MongoDB server representation.
 use {Client, Result};
 use Error::{self, OperationError};
 

--- a/src/wire_protocol/flags.rs
+++ b/src/wire_protocol/flags.rs
@@ -1,3 +1,4 @@
+//! Operation flags.
 use coll::options::{CursorType, FindOptions};
 
 /// Represents the bit vector of options for an OP_REPLY message.

--- a/src/wire_protocol/header.rs
+++ b/src/wire_protocol/header.rs
@@ -1,3 +1,4 @@
+//! Message headers.
 use std::fmt;
 use std::io::{Read, Write};
 
@@ -39,11 +40,6 @@ impl OpCode {
 }
 
 impl fmt::Display for OpCode {
-    /// Gets the string representation of an opcode.
-    ///
-    /// # Return value
-    ///
-    /// Returns the string represetnation of the opcode.
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &OpCode::Reply => write!(fmt, "OP_REPLY"),
@@ -56,117 +52,52 @@ impl fmt::Display for OpCode {
 }
 
 /// Represents a header in the MongoDB Wire Protocol.
-///
-/// # Fields
-///
-/// `message_length` - The length of the entire message in bytes.
-/// `request_id` - Identifies the request being sent. This should be `0` in a
-///                response from the server.
-/// `response_to` - Identifies which response the message is a response to. This
-///                 should be `0` in a request from the client.
-/// `op_code`     - Identifies which type of message is being sent.
-// #[derive(Clone)]
+#[derive(Clone)]
 pub struct Header {
+    /// The length of the entire message, in bytes.
     pub message_length: i32,
+    /// Identifies the request being sent. From a server response, this should be '0'.
     pub request_id: i32,
+    // Identifies which response this message is a response to. From a client request, this should be '0'.
     response_to: i32,
+    /// Identifies which type of message is being sent.
     pub op_code: OpCode,
 }
 
 impl Header {
     /// Constructs a new Header.
-    ///
-    /// # Arguments
-    ///
-    /// `message_length` - The length of the message in bytes.
-    /// `request_id` - Identifier for the request, or `0` if the the message
-    ///                is a response.
-    /// `response_to` - Identifies which request the message is in response to,
-    ///                or `0` if the the message is a request.
-    /// `op_code` - Identifies which type of message is being sent.
-    ///
-    /// # Return value
-    ///
-    /// Returns the newly-created Header.
     pub fn new(message_length: i32, request_id: i32, response_to: i32,
            op_code: OpCode) -> Header {
         Header { message_length: message_length, request_id: request_id,
                  response_to: response_to, op_code: op_code }
     }
 
-    /// Construcs a new Header for a request.
-    ///
-    /// # Arguments
-    ///
-    /// `message_length` - The length of the message in bytes.
-    /// `request_id` - Identifier for the request, or `0` if the the message
-    ///                is a response.
-    /// `op_code` - Identifies which type of message is being sent.
-    ///
-    /// # Return value
-    ///
-    /// Returns a new Header with `response_to` set to 0.
+    /// Constructs a new Header for a request, with `response_to` set to 0.
     fn new_request(message_length: i32, request_id: i32,
                    op_code: OpCode) -> Header {
         Header::new(message_length, request_id, 0, op_code)
     }
 
-    /// Constructs a new Header for an OP_UPDATE.
-    ///
-    /// # Arguments
-    ///
-    /// `message_length` - The length of the message in bytes.
-    /// `request_id` - Identifier for the request, or `0` if the the message
-    ///                is a response.
-    /// # Return value
-    ///
-    /// Returns a new Header with `response_to` set to 0 and `op_code`
-    /// set to `Update`.
+    /// Constructs a new Header for an OP_UPDATE, with `response_to` set to 0 and
+    /// `op_code` set to `Update`.
     pub fn new_update(message_length: i32, request_id: i32) -> Header {
         Header::new_request(message_length, request_id, OpCode::Update)
     }
 
-    /// Constructs a new Header for an OP_INSERT.
-    ///
-    /// # Arguments
-    ///
-    /// `message_length` - The length of the message in bytes.
-    /// `request_id` - Identifier for the request, or `0` if the the message
-    ///                is a response.
-    /// # Return value
-    ///
-    /// Returns a new Header with `response_to` set to 0 and `op_code`
-    /// set to `Insert`.
+    /// Constructs a new Header for an OP_INSERT, with `response_to` set to 0 and
+    /// `op_code` set to `Insert`.
     pub fn new_insert(message_length: i32, request_id: i32) -> Header {
         Header::new_request(message_length, request_id, OpCode::Insert)
     }
 
-    /// Constructs a new Header for an OP_QUERY.
-    ///
-    /// # Arguments
-    ///
-    /// `message_length` - The length of the message in bytes.
-    /// `request_id` - Identifier for the request, or `0` if the the message
-    ///                is a response.
-    /// # Return value
-    ///
-    /// Returns a new Header with `response_to` set to 0 and `op_code`
-    /// set to `Query`.
+    /// Constructs a new Header for an OP_QUERY, with `response_to` set to 0 and
+    /// `op_code` set to `Query`.
     pub fn new_query(message_length: i32, request_id: i32) -> Header {
         Header::new_request(message_length, request_id, OpCode::Query)
     }
 
-    /// Constructs a new Header for an OP_GET_MORE.
-    ///
-    /// # Arguments
-    ///
-    /// `message_length` - The length of the message in bytes.
-    /// `request_id` - Identifier for the request, or `0` if the the message
-    ///                is a response.
-    /// # Return value
-    ///
-    /// Returns a new Header with `response_to` set to 0 and `op_code`
-    /// set to `GetMore`.
+    /// Constructs a new Header for an OP_GET_MORE, with `response_to` set to 0 and
+    /// `op_code` set to `GetMore`.
     pub fn new_get_more(message_length: i32, request_id: i32) -> Header {
         Header::new_request(message_length, request_id, OpCode::GetMore)
     }

--- a/src/wire_protocol/mod.rs
+++ b/src/wire_protocol/mod.rs
@@ -1,3 +1,4 @@
+//! Low-level client-server communication over the MongoDB wire protocol.
 mod header;
 pub mod flags;
 pub mod operations;


### PR DESCRIPTION
* Added documentation for most modules (inner modules are mostly single-line descriptions).
* Added documentation for some structs and methods that were missing it.
* Organized documentation, e.g.
    * Moved Client and Database function documentation to the traits, so that they are actually shown in the docs.
    * Moved argument documentation from wire_protocol functions to the actual enum fields for OpQuery, OpUpdate, etc.

You can check the documentation [here](http://kyeah.github.io/mongo-rust-driver-prototype/mongodb/) on my personal gh-pages branch. Not sure if we want to preserve the old gh-pages as a separate branch or just make a commit on top of it?