### PR TITLE
Buffered Connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "mongodb"
 version = "0.1.0"
 dependencies = [
  "bson 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bufstream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "nalgebra 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,6 +38,11 @@ dependencies = [
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bufstream"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ scan_fmt = "0.1.0"
 separator = "0.3.0"
 textnonce = "0.1.1"
 time = "0.1"
+bufstream = "0.1.1"
 
 [dev-dependencies]
 nalgebra = "0.2"

--- a/src/connstring.rs
+++ b/src/connstring.rs
@@ -105,7 +105,7 @@ pub fn parse(address: &str) -> Result<ConnectionString> {
     // Remove scheme
     let addr = &address[URI_SCHEME.len()..];
 
-    let mut hosts: Vec<Host>;
+    let hosts: Vec<Host>;
     let mut user: Option<String> = None;
     let mut password: Option<String> = None;
     let mut database: Option<String> = Some("test".to_owned());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ extern crate scan_fmt;
 extern crate separator;
 extern crate textnonce;
 extern crate time;
+extern crate bufstream;
 
 pub mod db;
 pub mod coll;

--- a/src/wire_protocol/operations.rs
+++ b/src/wire_protocol/operations.rs
@@ -229,8 +229,8 @@ impl Message {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    fn write_bson_document(buffer: &mut Write,
-                           bson: &bson::Document) -> Result<()>{
+    fn write_bson_document<W: Write>(buffer: &mut W,
+                                     bson: &bson::Document) -> Result<()>{
         let mut temp_buffer = vec![];
 
         try!(bson::encode_document(&mut temp_buffer, bson));
@@ -253,9 +253,9 @@ impl Message {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    pub fn write_update(buffer: &mut Write, header: &Header, namespace: &str,
-                        flags: &OpUpdateFlags, selector: &bson::Document,
-                        update: &bson::Document) -> Result<()> {
+    pub fn write_update<W: Write>(buffer: &mut W, header: &Header, namespace: &str,
+                                  flags: &OpUpdateFlags, selector: &bson::Document,
+                                  update: &bson::Document) -> Result<()> {
 
         try!(header.write(buffer));
 
@@ -292,8 +292,8 @@ impl Message {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    fn write_insert(buffer: &mut Write, header: &Header, flags: &OpInsertFlags,
-                    namespace: &str, documents: &[bson::Document]) -> Result<()> {
+    fn write_insert<W: Write>(buffer: &mut W, header: &Header, flags: &OpInsertFlags,
+                              namespace: &str, documents: &[bson::Document]) -> Result<()> {
 
         try!(header.write(buffer));
         try!(buffer.write_i32::<LittleEndian>(flags.to_i32()));
@@ -334,11 +334,11 @@ impl Message {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    fn write_query(buffer: &mut Write, header: &Header,
-                   flags: &OpQueryFlags, namespace: &str,
-                   number_to_skip: i32, number_to_return: i32,
-                   query: &bson::Document,
-                   return_field_selector: &Option<bson::Document>) -> Result<()> {
+    fn write_query<W: Write>(buffer: &mut W, header: &Header,
+                             flags: &OpQueryFlags, namespace: &str,
+                             number_to_skip: i32, number_to_return: i32,
+                             query: &bson::Document,
+                             return_field_selector: &Option<bson::Document>) -> Result<()> {
 
         try!(header.write(buffer));
         try!(buffer.write_i32::<LittleEndian>(flags.to_i32()));
@@ -378,8 +378,8 @@ impl Message {
     /// # Return value
     ///
     /// Returns nothing on success, or an Error on failure.
-    pub fn write_get_more(buffer: &mut Write, header: &Header, namespace: &str,
-                          number_to_return: i32, cursor_id: i64) -> Result<()> {
+    pub fn write_get_more<W: Write>(buffer: &mut W, header: &Header, namespace: &str,
+                                    number_to_return: i32, cursor_id: i64) -> Result<()> {
 
         try!(header.write(buffer));
 
@@ -409,7 +409,7 @@ impl Message {
     /// # Return value
     ///
     /// Returns nothing on success, or an error string on failure.
-    pub fn write(&self, buffer: &mut Write) -> Result<()> {
+    pub fn write<W: Write>(&self, buffer: &mut W) -> Result<()> {
         match self {
             /// Only the server should send replies
             &Message::OpReply {..} =>
@@ -445,7 +445,7 @@ impl Message {
     /// # Return value
     ///
     /// Returns the reply message on success, or an Error on failure.
-    fn read_reply(buffer: &mut Read, header: Header) -> Result<Message> {
+    fn read_reply<R: Read>(buffer: &mut R, header: Header) -> Result<Message> {
         let mut length = header.message_length - mem::size_of::<Header>() as i32;
 
         // Read flags


### PR DESCRIPTION
With `std::net::TcpStream`, there are a lot of calls to `sendto` with just one byte. The following output is from `strace`:

    connect(4, {sa_family=AF_INET, sin_port=htons(27017), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
    getpeername(4, {sa_family=AF_INET, sin_port=htons(27017), sin_addr=inet_addr("127.0.0.1")}, [16]) = 0
    sendto(4, "G\0\0\0", 4, 0, NULL, 0)     = 4
    sendto(4, "\1\0\0\0", 4, 0, NULL, 0)    = 4
    sendto(4, "\0\0\0\0", 4, 0, NULL, 0)    = 4
    sendto(4, "\324\7\0\0", 4, 0, NULL, 0)  = 4
    sendto(4, "\4\0\0\0", 4, 0, NULL, 0)    = 4
    sendto(4, "b", 1, 0, NULL, 0)           = 1
    sendto(4, "a", 1, 0, NULL, 0)           = 1
    sendto(4, "s", 1, 0, NULL, 0)           = 1
    sendto(4, "i", 1, 0, NULL, 0)           = 1
    sendto(4, "c", 1, 0, NULL, 0)           = 1
    sendto(4, "-", 1, 0, NULL, 0)           = 1
    sendto(4, "t", 1, 0, NULL, 0)           = 1
    sendto(4, "e", 1, 0, NULL, 0)           = 1
    sendto(4, "s", 1, 0, NULL, 0)           = 1
    sendto(4, "t", 1, 0, NULL, 0)           = 1
    sendto(4, ".", 1, 0, NULL, 0)           = 1
    sendto(4, "d", 1, 0, NULL, 0)           = 1
    sendto(4, "a", 1, 0, NULL, 0)           = 1
    sendto(4, "t", 1, 0, NULL, 0)           = 1
    sendto(4, "a", 1, 0, NULL, 0)           = 1
    sendto(4, "b", 1, 0, NULL, 0)           = 1
    sendto(4, "a", 1, 0, NULL, 0)           = 1
    sendto(4, "s", 1, 0, NULL, 0)           = 1
    sendto(4, "e", 1, 0, NULL, 0)           = 1
    sendto(4, "s", 1, 0, NULL, 0)           = 1
    sendto(4, "\0", 1, 0, NULL, 0)          = 1
    [...]

The crate [`bufstream`](https://crates.io/crates/bufstream) can be used to reduce the syscalls:

    connect(4, {sa_family=AF_INET, sin_port=htons(27017), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
    getpeername(4, {sa_family=AF_INET, sin_port=htons(27017), sin_addr=inet_addr("127.0.0.1")}, [16]) = 0
    sendto(4, "G\0\0\0\1\0\0\0\0\0\0\0\324\7\0\0", 16, 0, NULL, 0) = 16
    sendto(4, "\4\0\0\0basic-test.databases\0\0\0\0\0\24\0\0"..., 55, 0, NULL, 0) = 55
