### PR TITLE
Remove unnecessary "to_owned" calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,15 +2,15 @@
 name = "mongodb"
 version = "0.1.0"
 dependencies = [
- "bson 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bson 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "nalgebra 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nalgebra 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "scan_fmt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scan_fmt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "separator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textnonce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -21,21 +21,21 @@ name = "advapi32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bson"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -54,60 +54,60 @@ name = "chrono"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kernel32-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nalgebra"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num"
-version = "0.1.25"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,21 +115,21 @@ name = "rust-crypto"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scan_fmt"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -142,8 +142,8 @@ name = "textnonce"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -152,14 +152,14 @@ name = "time"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["mongo", "mongodb", "database", "bson", "nosql"]
 license = "Apache-2.0"
 
 [dependencies]
-bson = "0.1.3"
+bson = "0.1.4"
 byteorder = "0.3"
 chrono = "0.2"
 rand = "0.3"

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -93,12 +93,12 @@ impl Collection {
 
         let mut spec = bson::Document::new();
         let mut cursor = bson::Document::new();
-        cursor.insert("batchSize".to_owned(), Bson::I32(opts.batch_size));
-        spec.insert("aggregate".to_owned(), Bson::String(self.name()));
-        spec.insert("pipeline".to_owned(), Bson::Array(pipeline_map));
-        spec.insert("cursor".to_owned(), Bson::Document(cursor));
+        cursor.insert("batchSize", Bson::I32(opts.batch_size));
+        spec.insert("aggregate", Bson::String(self.name()));
+        spec.insert("pipeline", Bson::Array(pipeline_map));
+        spec.insert("cursor", Bson::Document(cursor));
         if opts.allow_disk_use {
-            spec.insert("allowDiskUse".to_owned(), Bson::Boolean(opts.allow_disk_use));
+            spec.insert("allowDiskUse", Bson::Boolean(opts.allow_disk_use));
         }
 
         let read_pref = opts.read_preference.unwrap_or(self.read_preference.to_owned());
@@ -111,18 +111,18 @@ impl Collection {
         let opts = options.unwrap_or(CountOptions::new());
 
         let mut spec = bson::Document::new();
-        spec.insert("count".to_owned(), Bson::String(self.name()));
-        spec.insert("skip".to_owned(), Bson::I64(opts.skip as i64));
-        spec.insert("limit".to_owned(), Bson::I64(opts.limit));
+        spec.insert("count", Bson::String(self.name()));
+        spec.insert("skip", Bson::I64(opts.skip as i64));
+        spec.insert("limit", Bson::I64(opts.limit));
         if filter.is_some() {
-            spec.insert("query".to_owned(), Bson::Document(filter.unwrap()));
+            spec.insert("query", Bson::Document(filter.unwrap()));
         }
 
         // Favor specified hint document over string
         if opts.hint_doc.is_some() {
-            spec.insert("hint".to_owned(), Bson::Document(opts.hint_doc.unwrap()));
+            spec.insert("hint", Bson::Document(opts.hint_doc.unwrap()));
         } else if opts.hint.is_some() {
-            spec.insert("hint".to_owned(), Bson::String(opts.hint.unwrap()));
+            spec.insert("hint", Bson::String(opts.hint.unwrap()));
         }
 
         let read_pref = opts.read_preference.unwrap_or(self.read_preference.to_owned());
@@ -141,10 +141,10 @@ impl Collection {
         let opts = options.unwrap_or(DistinctOptions::new());
 
         let mut spec = bson::Document::new();
-        spec.insert("distinct".to_owned(), Bson::String(self.name()));
-        spec.insert("key".to_owned(), Bson::String(field_name.to_owned()));
+        spec.insert("distinct", Bson::String(self.name()));
+        spec.insert("key", Bson::String(field_name.to_owned()));
         if filter.is_some() {
-            spec.insert("query".to_owned(), Bson::Document(filter.unwrap()));
+            spec.insert("query", Bson::Document(filter.unwrap()));
         }
 
         let read_pref = opts.read_preference.unwrap_or(self.read_preference.to_owned());
@@ -217,14 +217,14 @@ impl Collection {
         let wc = write_concern.unwrap_or(self.write_concern.clone());
 
         let mut new_cmd = bson::Document::new();
-        new_cmd.insert("findAndModify".to_owned(), Bson::String(self.name()));
-        new_cmd.insert("query".to_owned(), Bson::Document(filter));
-        new_cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
+        new_cmd.insert("findAndModify", Bson::String(self.name()));
+        new_cmd.insert("query", Bson::Document(filter));
+        new_cmd.insert("writeConcern", Bson::Document(wc.to_bson()));
         if sort.is_some() {
-            new_cmd.insert("sort".to_owned(), Bson::Document(sort.unwrap()));
+            new_cmd.insert("sort", Bson::Document(sort.unwrap()));
         }
         if projection.is_some() {
-            new_cmd.insert("fields".to_owned(), Bson::Document(projection.unwrap()));
+            new_cmd.insert("fields", Bson::Document(projection.unwrap()));
         }
 
         for (key, val) in cmd.iter() {
@@ -249,12 +249,12 @@ impl Collection {
                                       Option<WriteConcern>, cmd_type: CommandType) -> Result<Option<bson::Document>> {
 
         let mut cmd = bson::Document::new();
-        cmd.insert("update".to_owned(), Bson::Document(update));
+        cmd.insert("update", Bson::Document(update));
         if after {
-            cmd.insert("new".to_owned(), Bson::Boolean(true));
+            cmd.insert("new", Bson::Boolean(true));
         }
         if upsert {
-            cmd.insert("upsert".to_owned(), Bson::Boolean(true));
+            cmd.insert("upsert", Bson::Boolean(true));
         }
 
         self.find_and_modify(&mut cmd, filter, max_time_ms, projection, sort, write_concern,
@@ -267,7 +267,7 @@ impl Collection {
 
         let opts = options.unwrap_or(FindOneAndDeleteOptions::new());
         let mut cmd = bson::Document::new();
-        cmd.insert("remove".to_owned(), Bson::Boolean(true));
+        cmd.insert("remove", Bson::Boolean(true));
         self.find_and_modify(&mut cmd, filter, opts.max_time_ms,
                              opts.projection, opts.sort, opts.write_concern,
                              CommandType::FindOneAndDelete)
@@ -483,7 +483,7 @@ impl Collection {
                 Some(id) => ids.push(id.clone()),
                 None => {
                     let id = Bson::ObjectId(try!(oid::ObjectId::new()));
-                    cdoc.insert("_id".to_owned(), id.clone());
+                    cdoc.insert("_id", id.clone());
                     ids.push(id);
                 }
             }
@@ -491,10 +491,10 @@ impl Collection {
         }
 
         let mut cmd = bson::Document::new();
-        cmd.insert("insert".to_owned(), Bson::String(self.name()));
-        cmd.insert("documents".to_owned(), Bson::Array(converted_docs));
-        cmd.insert("ordered".to_owned(), Bson::Boolean(ordered));
-        cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
+        cmd.insert("insert", Bson::String(self.name()));
+        cmd.insert("documents", Bson::Array(converted_docs));
+        cmd.insert("ordered", Bson::Boolean(ordered));
+        cmd.insert("writeConcern", Bson::Document(wc.to_bson()));
 
         let result = try!(self.db.command(cmd, cmd_type, None));
 
@@ -568,19 +568,19 @@ impl Collection {
         let mut deletes = Vec::new();
         for model in models {
             let mut delete = bson::Document::new();
-            delete.insert("q".to_owned(), Bson::Document(model.filter));
+            delete.insert("q", Bson::Document(model.filter));
             let limit = if model.multi { 0 } else { 1 };
-            delete.insert("limit".to_owned(), Bson::I64(limit));
+            delete.insert("limit", Bson::I64(limit));
             deletes.push(Bson::Document(delete));
         }
 
         let mut cmd = bson::Document::new();
-        cmd.insert("delete".to_owned(), Bson::String(self.name()));
-        cmd.insert("deletes".to_owned(), Bson::Array(deletes));
+        cmd.insert("delete", Bson::String(self.name()));
+        cmd.insert("deletes", Bson::Array(deletes));
         if !ordered {
-            cmd.insert("ordered".to_owned(), Bson::Boolean(ordered));
+            cmd.insert("ordered", Bson::Boolean(ordered));
         }
-        cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
+        cmd.insert("writeConcern", Bson::Document(wc.to_bson()));
 
         let result = try!(self.db.command(cmd, cmd_type, None));
 
@@ -631,22 +631,22 @@ impl Collection {
         let mut updates = Vec::new();
         for model in models {
             let mut update = bson::Document::new();
-            update.insert("q".to_owned(), Bson::Document(model.filter));
-            update.insert("u".to_owned(), Bson::Document(model.update));
-            update.insert("upsert".to_owned(), Bson::Boolean(model.upsert));
+            update.insert("q", Bson::Document(model.filter));
+            update.insert("u", Bson::Document(model.update));
+            update.insert("upsert", Bson::Boolean(model.upsert));
             if !ordered {
-                update.insert("ordered".to_owned(), Bson::Boolean(ordered));
+                update.insert("ordered", Bson::Boolean(ordered));
             }
             if model.multi {
-                update.insert("multi".to_owned(), Bson::Boolean(model.multi));
+                update.insert("multi", Bson::Boolean(model.multi));
             }
             updates.push(Bson::Document(update));
         }
 
         let mut cmd = bson::Document::new();
-        cmd.insert("update".to_owned(), Bson::String(self.name()));
-        cmd.insert("updates".to_owned(), Bson::Array(updates));
-        cmd.insert("writeConcern".to_owned(), Bson::Document(wc.to_bson()));
+        cmd.insert("update", Bson::String(self.name()));
+        cmd.insert("updates", Bson::Array(updates));
+        cmd.insert("writeConcern", Bson::Document(wc.to_bson()));
 
         let result = try!(self.db.command(cmd, cmd_type, None));
 
@@ -741,8 +741,8 @@ impl Collection {
         }
 
         let mut cmd = bson::Document::new();
-        cmd.insert("createIndexes".to_owned(), Bson::String(self.name()));
-        cmd.insert("indexes".to_owned(), Bson::Array(indexes));
+        cmd.insert("createIndexes", Bson::String(self.name()));
+        cmd.insert("indexes", Bson::Array(indexes));
         let result = try!(self.db.command(cmd, CommandType::CreateIndexes, None));
 
         match result.get("errmsg") {
@@ -769,8 +769,8 @@ impl Collection {
     /// Drop an index by IndexModel.
     pub fn drop_index_model(&self, model: IndexModel) -> Result<()> {
         let mut cmd = bson::Document::new();
-        cmd.insert("dropIndexes".to_owned(), Bson::String(self.name()));
-        cmd.insert("index".to_owned(), Bson::String(try!(model.name())));
+        cmd.insert("dropIndexes", Bson::String(self.name()));
+        cmd.insert("index", Bson::String(try!(model.name())));
 
         let result = try!(self.db.command(cmd, CommandType::DropIndexes, None));
         match result.get("errmsg") {
@@ -791,7 +791,7 @@ impl Collection {
     /// List all indexes in the collection.
     pub fn list_indexes(&self) -> Result<Cursor> {
         let mut cmd = bson::Document::new();
-        cmd.insert("listIndexes".to_owned(), Bson::String(self.name()));
+        cmd.insert("listIndexes", Bson::String(self.name()));
         self.db.command_cursor(cmd, CommandType::ListIndexes, self.read_preference.to_owned())
     }
 }

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -311,57 +311,57 @@ impl IndexModel {
     /// Converts the model to its BSON document representation.
     pub fn to_bson(&self) -> Result<bson::Document> {
         let mut doc = bson::Document::new();
-        doc.insert("key".to_owned(), Bson::Document(self.keys.clone()));
+        doc.insert("key", Bson::Document(self.keys.clone()));
 
         if let Some(ref val) = self.options.background {
-            doc.insert("background".to_owned(), Bson::Boolean(*val));
+            doc.insert("background", Bson::Boolean(*val));
         }
         if let Some(ref val) = self.options.expire_after_seconds {
-            doc.insert("expireAfterSeconds".to_owned(), Bson::I32(*val));
+            doc.insert("expireAfterSeconds", Bson::I32(*val));
         }
         if let Some(ref val) = self.options.name {
-            doc.insert("name".to_owned(), Bson::String(val.to_owned()));
+            doc.insert("name", Bson::String(val.to_owned()));
         } else {
-            doc.insert("name".to_owned(), Bson::String(try!(self.generate_index_name())));
+            doc.insert("name", Bson::String(try!(self.generate_index_name())));
         }
         if let Some(ref val) = self.options.sparse {
-            doc.insert("sparse".to_owned(), Bson::Boolean(*val));
+            doc.insert("sparse", Bson::Boolean(*val));
         }
         if let Some(ref val) = self.options.storage_engine {
-            doc.insert("storageEngine".to_owned(), Bson::String(val.to_owned()));
+            doc.insert("storageEngine", Bson::String(val.to_owned()));
         }
         if let Some(ref val) = self.options.unique {
-            doc.insert("unique".to_owned(), Bson::Boolean(*val));
+            doc.insert("unique", Bson::Boolean(*val));
         }
         if let Some(ref val) = self.options.version {
-            doc.insert("v".to_owned(), Bson::I32(*val));
+            doc.insert("v", Bson::I32(*val));
         }
         if let Some(ref val) = self.options.default_language {
-            doc.insert("default_language".to_owned(), Bson::String(val.to_owned()));
+            doc.insert("default_language", Bson::String(val.to_owned()));
         }
         if let Some(ref val) = self.options.language_override {
-            doc.insert("language_override".to_owned(), Bson::String(val.to_owned()));
+            doc.insert("language_override", Bson::String(val.to_owned()));
         }
         if let Some(ref val) = self.options.text_version {
-            doc.insert("textIndexVersion".to_owned(), Bson::I32(*val));
+            doc.insert("textIndexVersion", Bson::I32(*val));
         }
         if let Some(ref val) = self.options.weights {
-            doc.insert("weights".to_owned(), Bson::Document(val.clone()));
+            doc.insert("weights", Bson::Document(val.clone()));
         }
         if let Some(ref val) = self.options.sphere_version {
-            doc.insert("2dsphereIndexVersion".to_owned(), Bson::I32(*val));
+            doc.insert("2dsphereIndexVersion", Bson::I32(*val));
         }
         if let Some(ref val) = self.options.bits {
-            doc.insert("bits".to_owned(), Bson::I32(*val));
+            doc.insert("bits", Bson::I32(*val));
         }
         if let Some(ref val) = self.options.max {
-            doc.insert("max".to_owned(), Bson::FloatingPoint(*val));
+            doc.insert("max", Bson::FloatingPoint(*val));
         }
         if let Some(ref val) = self.options.min {
-            doc.insert("min".to_owned(), Bson::FloatingPoint(*val));
+            doc.insert("min", Bson::FloatingPoint(*val));
         }
         if let Some(ref val) = self.options.bucket_size {
-            doc.insert("bucketSize".to_owned(), Bson::I32(*val));
+            doc.insert("bucketSize", Bson::I32(*val));
         }
 
         Ok(doc)

--- a/src/common.rs
+++ b/src/common.rs
@@ -52,12 +52,12 @@ impl ReadPreference {
         let bson_tag_sets: Vec<_> = self.tag_sets.iter().map(|map| {
             let mut bson_map = bson::Document::new();
             for (key, val) in map.iter() {
-                bson_map.insert(key.to_owned(), Bson::String(val.to_owned()));
+                bson_map.insert(&key[..], Bson::String(val.to_owned()));
             }
             Bson::Document(bson_map)
         }).collect();
 
-        doc.insert("tag_sets".to_owned(), Bson::Array(bson_tag_sets));
+        doc.insert("tag_sets", Bson::Array(bson_tag_sets));
         doc
     }
 }
@@ -86,9 +86,9 @@ impl WriteConcern {
 
     pub fn to_bson(&self) -> bson::Document {
         let mut bson = bson::Document::new();
-        bson.insert("w".to_owned(), Bson::I32(self.w));
-        bson.insert("wtimeout".to_owned(), Bson::I32(self.w_timeout));
-        bson.insert("j".to_owned(), Bson::Boolean(self.j));
+        bson.insert("w", Bson::I32(self.w));
+        bson.insert("wtimeout", Bson::I32(self.w_timeout));
+        bson.insert("j", Bson::Boolean(self.j));
         bson
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -223,13 +223,13 @@ impl Cursor {
                 Some(_) => {
                     // Query is already formatted as a $query document; add onto it.
                     let mut nq = query.clone();
-                    nq.insert("read_preference".to_owned(), Bson::Document(read_pref.to_document()));
+                    nq.insert("read_preference", Bson::Document(read_pref.to_document()));
                     nq
                 },
                 None => {
                     // Convert the query to a $query document.
                     let mut nq = doc! { "$query" => query };
-                    nq.insert("read_preference".to_owned(), Bson::Document(read_pref.to_document()));
+                    nq.insert("read_preference", Bson::Document(read_pref.to_document()));
                     nq
                 }
             }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -198,11 +198,11 @@ impl ThreadedDatabase for Database {
         let mut spec = bson::Document::new();
         let mut cursor = bson::Document::new();
 
-        cursor.insert("batchSize".to_owned(), Bson::I32(batch_size));
-        spec.insert("listCollections".to_owned(), Bson::I32(1));
-        spec.insert("cursor".to_owned(), Bson::Document(cursor));
+        cursor.insert("batchSize", Bson::I32(batch_size));
+        spec.insert("listCollections", Bson::I32(1));
+        spec.insert("cursor", Bson::Document(cursor));
         if filter.is_some() {
-            spec.insert("filter".to_owned(), Bson::Document(filter.unwrap()));
+            spec.insert("filter", Bson::Document(filter.unwrap()));
         }
 
         self.command_cursor(spec, CommandType::ListCollections, self.read_preference.to_owned())
@@ -232,17 +232,17 @@ impl ThreadedDatabase for Database {
         };
 
         if let Some(i) = coll_options.size {
-            doc.insert("size".to_owned(), Bson::I64(i));
+            doc.insert("size", Bson::I64(i));
         }
 
         if let Some(i) = coll_options.max {
-            doc.insert("max".to_owned(), Bson::I64(i));
+            doc.insert("max", Bson::I64(i));
         }
 
         let flag_one = if coll_options.use_power_of_two_sizes { 1 } else { 0 };
         let flag_two = if coll_options.no_padding { 2 } else { 0 };
 
-        doc.insert("flags".to_owned(), Bson::I32(flag_one + flag_two));
+        doc.insert("flags", Bson::I32(flag_one + flag_two));
 
         self.command(doc, CommandType::CreateCollection, None).map(|_| ())
     }
@@ -256,13 +256,13 @@ impl ThreadedDatabase for Database {
         };
 
         if let Some(data) = user_options.custom_data {
-            doc.insert("customData".to_owned(), Bson::Document(data));
+            doc.insert("customData", Bson::Document(data));
         }
 
-        doc.insert("roles".to_owned(), Role::to_bson_array(user_options.roles));
+        doc.insert("roles", Role::to_bson_array(user_options.roles));
 
         if let Some(concern) = user_options.write_concern {
-            doc.insert("writeConcern".to_owned(), Bson::Document(concern.to_bson()));
+            doc.insert("writeConcern", Bson::Document(concern.to_bson()));
         }
 
         self.command(doc, CommandType::CreateUser, None).map(|_| ())
@@ -272,7 +272,7 @@ impl ThreadedDatabase for Database {
         let mut doc = doc! { "dropAllUsersFromDatabase" => 1 };
 
         if let Some(concern) = write_concern {
-            doc.insert("writeConcern".to_owned(), Bson::Document(concern.to_bson()));
+            doc.insert("writeConcern", Bson::Document(concern.to_bson()));
         }
 
         let response = try!(self.command(doc, CommandType::DropAllUsers, None));
@@ -286,14 +286,14 @@ impl ThreadedDatabase for Database {
 
     fn drop_collection(&self, name: &str) -> Result<()> {
         let mut spec = bson::Document::new();
-        spec.insert("drop".to_owned(), Bson::String(name.to_owned()));
+        spec.insert("drop", Bson::String(name.to_owned()));
         try!(self.command(spec, CommandType::DropCollection, None));
         Ok(())
     }
 
     fn drop_database(&self) -> Result<()> {
         let mut spec = bson::Document::new();
-        spec.insert("dropDatabase".to_owned(), Bson::I32(1));
+        spec.insert("dropDatabase", Bson::I32(1));
         try!(self.command(spec, CommandType::DropDatabase, None));
         Ok(())
     }
@@ -302,7 +302,7 @@ impl ThreadedDatabase for Database {
         let mut doc = doc! { "dropUser" => name };
 
         if let Some(concern) = write_concern {
-            doc.insert("writeConcern".to_owned(), Bson::Document(concern.to_bson()));
+            doc.insert("writeConcern", Bson::Document(concern.to_bson()));
         }
 
         self.command(doc, CommandType::DropUser, None).map(|_| ())

--- a/src/gridfs/file.rs
+++ b/src/gridfs/file.rs
@@ -616,17 +616,17 @@ impl GfsFile {
         };
 
         if self.name.is_some() {
-            doc.insert("filename".to_owned(),
+            doc.insert("filename",
                        Bson::String(self.name.as_ref().unwrap().to_owned()));
         }
 
         if self.content_type.is_some() {
-            doc.insert("contentType".to_owned(),
+            doc.insert("contentType",
                        Bson::String(self.content_type.as_ref().unwrap().to_owned()));
         }
 
         if self.metadata.is_some() {
-            doc.insert("metadata".to_owned(),
+            doc.insert("metadata",
                        Bson::Binary(BinarySubtype::Generic,
                                     self.metadata.as_ref().unwrap().clone()));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! let client = Client::with_uri_and_options("mongodb://localhost:27017/", options)
 //!     .ok().expect("Failed to initialize client.");
 //! ```
-//! 
+//!
 //! ## Interacting with MongoDB Collections
 //!
 //! ```no_run
@@ -169,7 +169,7 @@ pub struct ClientOptions {
 
 impl ClientOptions {
     /// Creates a new default options struct.
-    pub fn new() -> ClientOptions {        
+    pub fn new() -> ClientOptions {
         ClientOptions {
             log_file: None,
             read_preference: None,
@@ -320,7 +320,7 @@ impl ThreadedClient for Client {
 
     fn database_names(&self) -> Result<Vec<String>> {
         let mut doc = bson::Document::new();
-        doc.insert("listDatabases".to_owned(), Bson::I32(1));
+        doc.insert("listDatabases", Bson::I32(1));
 
         let db = self.db("admin");
         let res = try!(db.command(doc, CommandType::ListDatabases, None));
@@ -348,7 +348,7 @@ impl ThreadedClient for Client {
 
     fn is_master(&self) -> Result<bool> {
         let mut doc = bson::Document::new();
-        doc.insert("isMaster".to_owned(), Bson::I32(1));
+        doc.insert("isMaster", Bson::I32(1));
 
         let db = self.db("local");
         let res = try!(db.command(doc, CommandType::IsMaster, None));

--- a/src/topology/monitor.rs
+++ b/src/topology/monitor.rs
@@ -234,7 +234,7 @@ impl Monitor {
         let options = FindOptions::new().with_limit(1);
         let flags = OpQueryFlags::with_find_options(&options);
         let mut filter = bson::Document::new();
-        filter.insert("isMaster".to_owned(), Bson::I32(1));
+        filter.insert("isMaster", Bson::I32(1));
 
         let stream = try!(self.personal_pool.acquire_stream());
 


### PR DESCRIPTION
The newest version of the "bson" crate (0.1.4) allows inserting key-value pairs into documents with any string type, not just owned strings. This pull request gets rid of all the "to_owned()" calls on string literal keys to make code a bit cleaner/more readable.